### PR TITLE
Fixes for issues reported by Coverity

### DIFF
--- a/app-metadata/runtime/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadata.java
+++ b/app-metadata/runtime/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadata.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.app.metadata;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -55,9 +56,9 @@ public final class AppMetadata {
     }
 
     public static AppMetadata load(Path file) {
-        try {
-            Properties props = new Properties();
-            props.load(Files.newBufferedReader(file));
+        Properties props = new Properties();
+        try (Reader fileReader = Files.newBufferedReader(file)) {
+            props.load(fileReader);
             return new AppMetadata(
                     props.getProperty("app-name"),
                     props.getProperty("http-root"),

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
@@ -137,7 +137,7 @@ public class HeroesOpenShiftIT {
     @Order(2)
     public void testUpdateHero() {
         Hero hero = new Hero();
-        hero.id = new Long(heroId);
+        hero.id = Long.valueOf(heroId);
         hero.name = UPDATED_NAME;
         hero.otherName = UPDATED_OTHER_NAME;
         hero.level = UPDATED_LEVEL;
@@ -183,7 +183,7 @@ public class HeroesOpenShiftIT {
             .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countDeleteHero'", is(1));
     }
 
-    class Hero {
+    static class Hero {
         public Long id;
         public String name;
         public String otherName;

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
@@ -138,7 +138,7 @@ public class VillainsOpenShiftIT {
     @Order(2)
     public void testUpdateVillain() {
         Villain villain = new Villain();
-        villain.id = new Long(villainId);
+        villain.id = Long.valueOf(villainId);
         villain.name = UPDATED_NAME;
         villain.otherName = UPDATED_OTHER_NAME;
         villain.level = UPDATED_LEVEL;
@@ -184,7 +184,7 @@ public class VillainsOpenShiftIT {
             .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countDeleteVillain'", is(1));
     }
 
-    class Villain {
+    static class Villain {
         public Long id;
         public String name;
         public String otherName;


### PR DESCRIPTION
Fixes for issues reported by Coverity

- Avoid deprecated constructor, make inner class static 
- Close BufferedReader in AppMetadata
