### PR TITLE
Updates for test applications with native mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,27 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-jvm${{ matrix.java }}.zip
+  build-released-native:
+    name: Native build - released Quarkus
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@v1.0.0
+        with:
+          java-version: openjdk${{ matrix.java }}
+      - name: Build with Maven
+        run: |
+          mvn -V -B clean install -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker
   build-master:
     name: JVM build - Quarkus master
     runs-on: ubuntu-latest
@@ -59,3 +80,26 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-jvm${{ matrix.java }}.zip
+  build-master-native:
+    name: Native build - Quarkus master
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@v1.0.0
+        with:
+          java-version: openjdk${{ matrix.java }}
+      - name: Build Quarkus master
+        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs -DskipDocs
+      - name: Build with Maven
+        run: |
+          mvn -V -B clean install -Dquarkus-core-only -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker

--- a/README.md
+++ b/README.md
@@ -258,6 +258,23 @@ This currently works automatically for the `target/kubernetes/openshift.yml` fil
 
 Note that it is usually a good idea to set `-Dts.image-overrides` to a _full_ path, because Maven changes the current working directory when running tests.
 
+### Native image
+
+The test suite contains a Maven profile configuring required system properties for native image build. The profile is
+activated by specifying the `native` Quarkus profile (`-Dquarkus.profile=native`). This profile does not specify the 
+container runtime for Quarkus native build, so by default, native build will use local GraalVM. The following command 
+will execute the whole test suite using Docker to run containers for native build:
+
+```
+./mvnw clean verify \
+  -Dquarkus.profile=native \ 
+  -Dquarkus.native.container-runtime=docker \
+  -Dts.authenticated-registry
+```
+
+Currently used builder image is `quarkus/ubi-quarkus-mandrel` and the base image for OpenShift deployment is 
+`quarkus/ubi-quarkus-native-binary-s2i`.
+
 ### TODO
 
 There's a lot of possible improvements that haven't been implemented yet.
@@ -277,6 +294,7 @@ The most interesting probably are:
   Currently, this isn't possible, and doesn't make too much sense, because for some actions, we just run `oc`, while for some, we use the Java client.
   We could possibly move towards doing everything through the Java library, but some things are hard (e.g. `oc start-build`).
   If we ever do this, then it becomes easily possible to consisently apply image overrides everywhere.
+- Implement a build workflow with `ubi8/ubi-minimal` instead of using `quarkus/ubi-quarkus-native-binary-s2i`.
 
 It would also be possible to create a Kubernetes variant: `@KubernetesTest`, `kubernetes.yml`, injection of `KubernetesClient`, etc.
 Most of the code could easily be shared.

--- a/configmap/src/main/java/io/quarkus/ts/openshift/configmap/Hello.java
+++ b/configmap/src/main/java/io/quarkus/ts/openshift/configmap/Hello.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.openshift.configmap;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class Hello {
     private final String content;
 

--- a/configmap/src/main/resources/application.properties
+++ b/configmap/src/main/resources/application.properties
@@ -4,3 +4,6 @@ quarkus.openshift.mounts.app-config.path=/deployments/config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
 
 %test.hello.message=Hello, %s!
+
+# This is mount point in quarkus/ubi-quarkus-native-binary-s2i
+%native.quarkus.openshift.mounts.app-config.path=/home/quarkus/config

--- a/pom.xml
+++ b/pom.xml
@@ -242,5 +242,22 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
+
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>quarkus.profile</name>
+                    <value>native</value>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Alpha2-java11</quarkus.native.builder-image>
+                <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/scaling/src/main/java/io/quarkus/ts/openshift/scaling/ScalingResource.java
+++ b/scaling/src/main/java/io/quarkus/ts/openshift/scaling/ScalingResource.java
@@ -10,11 +10,15 @@ import java.util.UUID;
 @Path("/scaling")
 public class ScalingResource {
 
-    private final static UUID uuid = UUID.randomUUID();
+    private static UUID uuid;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String get() {
+        // this is not exactly thread safe and should be fixed in the future
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
         return uuid.toString();
     }
 }


### PR DESCRIPTION
* Fixing issue with `ScalingOpenShiftIT` where the application instance identifier was determined at compile time
* Adding a `native-image` Quarkus profile to enable build of application with Mandrel builder image and deployment on respective S2I base image
* Adding a readme file section with notes on running this test suite with native image mode