### PR TITLE
Default to product coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build Quarkus master
         run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs -DskipDocs
       - name: Build with Maven
-        run: mvn -V -B clean test
+        run: mvn -V -B clean test -Dquarkus-core-only
       - name: Zip Artifacts
         run: |
           zip -R artifacts-jvm${{ matrix.java }}.zip 'surefire-reports/*'

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ All tests will run in the project you're logged into, so it should be empty.
 If there are resources deployed in the project, you should not expect they will survive.
 
 Running the tests amounts to standard `mvn clean verify`.
-This will use a specific Quarkus version, which can be modified by setting the `version.quarkus` property.
-Alternatively, you can use `-Dquarkus-core-only` to run the test suite against Quarkus `999-SNAPSHOT`.
-In that case, make sure you have built Quarkus locally prior to running the tests.
+This will use a specific version of Red Hat build of Quarkus, which can be modified by setting the `version.quarkus` property.
+Alternatively, you can use `-Dquarkus-core-only` to run the test suite against upstream Quarkus `999-SNAPSHOT`.
+In that case, make sure you have built Quarkus locally prior to running the tests or adjust the version using the `version.quarkus` property.
 
 All the tests currently use the RHEL 7 OpenJDK 11 image.
 This is configured in the `application.properties` file in each module.

--- a/app-metadata/deployment/pom.xml
+++ b/app-metadata/deployment/pom.xml
@@ -20,7 +20,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${version.quarkus}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>com.redhat.quarkus</quarkus.platform.group-id>
 
         <version.apache-httpclient-fluent>4.5.12</version.apache-httpclient-fluent> <!-- same as Apache HTTP Client managed by Quarkus BOM -->
         <version.fusesource-jansi>1.18</version.fusesource-jansi>
@@ -62,7 +62,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.3.3.Final</version.quarkus>
+        <version.quarkus>1.3.4.Final-redhat-00004</version.quarkus>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Default to product coordinates, for community coordinates `quarkus-core-only` profile can be used

`quarkus-universe-bom` is only available under `com.redhat.quarkus` groupId for RHBQ

Motivation: We should have consistent way to run the TS on product side (e.g. z-series team, interop testing)
