### PR TITLE
Fix the durability when sending messages to a non-durable AMQP address, enforced with reactive-messaging 2.2

### DIFF
--- a/messaging/amqp-reactive/src/main/resources/application.properties
+++ b/messaging/amqp-reactive/src/main/resources/application.properties
@@ -11,7 +11,6 @@ amqp-port=5672
 # Configure the AMQP connector to write to the `prices` address
 mp.messaging.outgoing.generated-price.connector=smallrye-amqp
 mp.messaging.outgoing.generated-price.address=prices
-mp.messaging.outgoing.generated-price.durable=true
 
 # Configure the AMQP connector to read from the `prices` queue
 mp.messaging.incoming.prices.connector=smallrye-amqp


### PR DESCRIPTION
Fix the durability when sending messages to a non-durable AMQP address, enforced with reactive-messaging 2.2

Fixes https://github.com/quarkus-qe/quarkus-openshift-test-suite/issues/66

Introduced in https://github.com/quarkusio/quarkus/commit/0dd61af3e6a7e6d92f121d53ebb85b429416ffce