### PR TITLE
Add commons-logging dependency to avoid NoClassDefFound org/apache/commons/logging/LogFactory

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,6 +46,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+        <!-- RestAssured depends on Apache HTTP Client, which depends on Commons Logging -->
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>


### PR DESCRIPTION
Add commons-logging dependency to avoid NoClassDefFound org/apache/commons/logging/LogFactory

Fixes https://github.com/quarkus-qe/quarkus-openshift-test-suite/issues/70, details are also described in https://github.com/quarkus-qe/quarkus-openshift-test-suite/issues/70
