### PR TITLE
quarkus-builder is in BOM starting with Quarkus 1.6

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-builder</artifactId>
-            <version>${version.quarkus}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus.ts.openshift</groupId>


### PR DESCRIPTION
quarkus-builder is in BOM starting with Quarkus 1.6