### PR TITLE
OpenShift Serverless support in test framework, first test for OpenShift Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ In such case, the `reason` attribute of the annotation should point to correspon
 
 If the test class is annotated `@ManualApplicationDeployment`, the `target/kubernetes/openshift.yml` file is ignored and the test application is _not_ deployed automatically.
 Instead, you should use `@AdditionalResources`, `@CustomizeApplicationDeployment` and `@CustomizeApplicationUndeployment` to deploy the application manually.
-The `@ManualApplicationDeployment` annotation then provides the necessary info about the application (such as the name or a known endpoint).
 
 This can be used to write tests that excersise an external application.
 You have full control over the application deployment and undeployment process, but the rest of the test can be written as if the application was part of the test suite.
+In such case, the deployed application can't use the `app-metadata` Quarkus extension, and you have to use the `@CustomAppMetadata` annotation to provide all the necessary information.
 
 ### Image overrides
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ public class HelloOpenShiftIT {
 The full set of objects that you can inject is:
 
 - `OpenShiftClient`: the Fabric8 Kubernetes client, in default configuration
+- `KnativeClient`: the Fabric8 Knative client, in default configuration
 - `AppMetadata`: provides convenient access to data collected in `target/app-metadata.properties`
 - `AwaitUtil`: utility to wait for some OpenShift resources
 - `OpenShiftUtil`: utility to perform higher-level actions on some OpenShift resources
@@ -274,6 +275,18 @@ will execute the whole test suite using Docker to run containers for native buil
 
 Currently used builder image is `quarkus/ubi-quarkus-mandrel` and the base image for OpenShift deployment is 
 `quarkus/ubi-quarkus-native-binary-s2i`.
+
+### OpenShift Serverless / Knative
+
+The test suite contains a Maven profile activated using the `include.serverless` property or `serverless` profile name.
+This profile includes additional modules with serverless test coverage into the execution of the testsuite.
+Serverless test coverage supports both JVM and Native mode.
+
+The following command will execute the whole test suite including serverless tests:
+
+```
+./mvnw clean verify -Dinclude.serverless
+```
 
 ### TODO
 
@@ -486,6 +499,12 @@ function properly on OpenShift, as well as the database integrations.
 ### `deployment-strategies/quarkus`
 
 A smoke test for deploying the application to OpenShift via `quarkus.kubernetes.deploy`.
+The test itself only verifies that a simple HTTP endpoint can be accessed.
+
+### `deployment-strategies/quarkus-serverless`
+
+A smoke test for deploying the application to OpenShift Serverless using combination of `quarkus.container-image.build`
+and `oc apply -f target/kubernetes/knative.yml` with slightly adjusted `knative.yml` file.
 The test itself only verifies that a simple HTTP endpoint can be accessed.
 
 ## Debugging failing tests

--- a/app-metadata/deployment/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadataCollector.java
+++ b/app-metadata/deployment/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadataCollector.java
@@ -7,6 +7,7 @@ import io.quarkus.deployment.builditem.GeneratedFileSystemResourceBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesHealthLivenessPathBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesHealthReadinessPathBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -34,10 +35,14 @@ public class AppMetadataCollector {
             knownEndpoint = httpRoot.adjustPath("/"); // TODO ?
         }
 
+        String deploymentTarget = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.kubernetes.deployment-target", String.class).orElse("");
+
         AppMetadata result = new AppMetadata(
                 appName,
                 httpRoot.getRootPath(),
-                knownEndpoint
+                knownEndpoint,
+                deploymentTarget
         );
 
         output.produce(new GeneratedFileSystemResourceBuildItem(

--- a/app-metadata/runtime/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadata.java
+++ b/app-metadata/runtime/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadata.java
@@ -36,11 +36,18 @@ public final class AppMetadata {
      * Otherwise, {@code /} is used.
      */
     public final String knownEndpoint;
+    /**
+     * The target deployment platform. Value can be kubernetes, openshift, knative,
+     * minikube etc, or any combination of the above as comma separated list.
+     * If not customized via {@code quarkus.kubernetes.deployment-target}, defaults to {@code kubernetes}.
+     */
+    public final String deploymentTarget;
 
-    public AppMetadata(String appName, String httpRoot, String knownEndpoint) {
+    public AppMetadata(String appName, String httpRoot, String knownEndpoint, String deploymentTarget) {
         this.appName = appName;
         this.httpRoot = httpRoot;
         this.knownEndpoint = knownEndpoint;
+        this.deploymentTarget = deploymentTarget;
     }
 
     @Override
@@ -49,6 +56,7 @@ public final class AppMetadata {
         data.put("app-name", appName);
         data.put("http-root", httpRoot);
         data.put("known-endpoint", knownEndpoint);
+        data.put("deployment-target", deploymentTarget);
         return data.entrySet()
                 .stream()
                 .map(entry -> entry.getKey() + "=" + entry.getValue() + "\n")
@@ -62,7 +70,8 @@ public final class AppMetadata {
             return new AppMetadata(
                     props.getProperty("app-name"),
                     props.getProperty("http-root"),
-                    props.getProperty("known-endpoint")
+                    props.getProperty("known-endpoint"),
+                    props.getProperty("deployment-target")
             );
         } catch (NoSuchFileException e) {
             throw new RuntimeException(file + " not found, did you add the app-metadata extension?", e);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>openshift-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>knative-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-builder</artifactId>
         </dependency>

--- a/common/src/main/java/io/quarkus/ts/openshift/common/CustomAppMetadata.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/CustomAppMetadata.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.openshift.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * If the test class is annotated {@code CustomAppMetadata}, then the annotation is used as a source
+ * of {@link io.quarkus.ts.openshift.app.metadata.AppMetadata} for the test. This must be used when deploying
+ * an application that lives outside of the test suite and can't use the {@code app-metadata} Quarkus extension.
+ *
+ * @see ManualApplicationDeployment
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomAppMetadata {
+    /**
+     * Name of the application, which is also used as a name of the Kubernetes resources.
+     * Corresponds to {@code quarkus.application.name} and/or {@code quarkus.container-image.name}.
+     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#appName
+     */
+    String appName();
+
+    /**
+     * Root path for the HTTP endpoint of the application.
+     * Corresponds to {@code quarkus.http.root-path}.
+     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#httpRoot
+     */
+    String httpRoot();
+
+    /**
+     * Known endpoint that can be used to find out if the application is already running.
+     * If the application has a readiness or liveness probe, it can be used here.
+     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#knownEndpoint
+     */
+    String knownEndpoint();
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/CustomAppMetadata.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/CustomAppMetadata.java
@@ -35,4 +35,10 @@ public @interface CustomAppMetadata {
      * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#knownEndpoint
      */
     String knownEndpoint();
+
+    /**
+     * The target deployment platform.
+     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#deploymentTarget
+     */
+    String deploymentTarget() default "";
 }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/ManualApplicationDeployment.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/ManualApplicationDeployment.java
@@ -8,31 +8,12 @@ import java.lang.annotation.Target;
 /**
  * If the test class is annotated {@code ManualApplicationDeployment}, tested application will not be deployed
  * automatically and it is expected that it will be deployed using {@link CustomizeApplicationDeployment} and
- * {@link AdditionalResources}. This annotation then provides the necessary information about the tested application.
- * If {@code CustomizeApplicationDeployment} is used to deploy the application,
+ * {@link AdditionalResources}. If {@code CustomizeApplicationDeployment} is used to deploy the application,
  * then {@link CustomizeApplicationUndeployment} should be used to undeploy it.
+ *
+ * @see CustomAppMetadata
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ManualApplicationDeployment {
-    /**
-     * Name of the application, which is also used as a name of the Kubernetes resources.
-     * Corresponds to {@code quarkus.application.name} and/or {@code quarkus.container-image.name}.
-     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#appName
-     */
-    String appName();
-
-    /**
-     * Root path for the HTTP endpoint of the application.
-     * Corresponds to {@code quarkus.http.root-path}.
-     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#httpRoot
-     */
-    String httpRoot();
-
-    /**
-     * Known endpoint that can be used to find out if the application is already running.
-     * If the application has a readiness or liveness probe, it can be used here.
-     * @see io.quarkus.ts.openshift.app.metadata.AppMetadata#knownEndpoint
-     */
-    String knownEndpoint();
 }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
@@ -55,6 +55,10 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
         return context.getElement().map(it -> it.getAnnotation(ManualApplicationDeployment.class));
     }
 
+    private Optional<CustomAppMetadata> getCustomAppMetadataAnnotation(ExtensionContext context) {
+        return context.getElement().map(it -> it.getAnnotation(CustomAppMetadata.class));
+    }
+
     private OpenShiftClient getOpenShiftClient(ExtensionContext context) {
         return getStore(context)
                 .getOrComputeIfAbsent(OpenShiftClientResource.class.getName(), ignored -> OpenShiftClientResource.createDefault(), OpenShiftClientResource.class)
@@ -66,13 +70,13 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
     }
 
     private AppMetadata getAppMetadata(ExtensionContext context) {
-        Optional<ManualApplicationDeployment> manualDeployment = getManualDeploymentAnnotation(context);
-        if (manualDeployment.isPresent()) {
+        Optional<CustomAppMetadata> customAppMetadata = getCustomAppMetadataAnnotation(context);
+        if (customAppMetadata.isPresent()) {
             return getStore(context)
                     .getOrComputeIfAbsent(AppMetadata.class.getName(), ignored -> new AppMetadata(
-                            manualDeployment.get().appName(),
-                            manualDeployment.get().httpRoot(),
-                            manualDeployment.get().knownEndpoint()
+                            customAppMetadata.get().appName(),
+                            customAppMetadata.get().httpRoot(),
+                            customAppMetadata.get().knownEndpoint()
                     ), AppMetadata.class);
         }
 

--- a/deployment-strategies/quarkus-serverless/.dockerignore
+++ b/deployment-strategies/quarkus-serverless/.dockerignore
@@ -1,0 +1,4 @@
+*
+!target/*-runner
+!target/*-runner.jar
+!target/lib/*

--- a/deployment-strategies/quarkus-serverless/pom.xml
+++ b/deployment-strategies/quarkus-serverless/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>deployment-strategies-quarkus-serverless</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Deployment Strategies Serverless: Quarkus</name>
+
+    <properties>
+        <!-- this could also be set in application.properties, but this is much closer to what users actually do -->
+        <!-- We do not use <quarkus.kubernetes.deploy>true</quarkus.kubernetes.deploy> intentionally, just the build -->
+        <quarkus.container-image.build>true</quarkus.container-image.build>
+        <quarkus.kubernetes-client.trust-certs>true</quarkus.kubernetes-client.trust-certs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>app-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.jvm
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,34 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/http-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/http-jvm
+#
+###
+FROM fabric8/java-alpine-openjdk8-jre:1.6.5
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
+
+# Be prepared for running in OpenShift too
+RUN adduser -G root --no-create-home --disabled-password 1001 \
+  && chown -R 1001 /deployments \
+  && chmod -R "g+rwX" /deployments \
+  && chown -R 1001:root /deployments
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+EXPOSE 8080
+
+# run with user 1001
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.native
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.native
@@ -1,0 +1,22 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the docker image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/http .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/http
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /work/
+COPY target/*-runner /work/application
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/deployment-strategies/quarkus-serverless/src/main/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/Hello.java
+++ b/deployment-strategies/quarkus-serverless/src/main/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/Hello.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.openshift.deployment.strategies.quarkus.serverless;
+
+public class Hello {
+    private final String content;
+
+    public Hello(String content) {
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}
+

--- a/deployment-strategies/quarkus-serverless/src/main/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/HelloResource.java
+++ b/deployment-strategies/quarkus-serverless/src/main/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/HelloResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.openshift.deployment.strategies.quarkus.serverless;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+    private static final String TEMPLATE = "Hello, %s!";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Hello get(@QueryParam("name") @DefaultValue("World") String name) {
+        return new Hello(String.format(TEMPLATE, name));
+    }
+}

--- a/deployment-strategies/quarkus-serverless/src/main/resources/application.properties
+++ b/deployment-strategies/quarkus-serverless/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.application.name=deployment-strategy-quarkus-serverless
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+
+quarkus.kubernetes.deployment-target=knative
+
+quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
+quarkus.container-image.group=to-be-replaced-by-current-namespace

--- a/deployment-strategies/quarkus-serverless/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/HelloTest.java
+++ b/deployment-strategies/quarkus-serverless/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/HelloTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.openshift.deployment.strategies.quarkus.serverless;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class HelloTest {
+    @Test
+    public void hello() {
+        when()
+                .get("/hello")
+        .then()
+                .statusCode(200)
+                .body("content", is("Hello, World!"));
+    }
+
+    @Test
+    public void parameterizedHello() {
+        given()
+        .when()
+                .queryParam("name", "Isaac")
+                .get("/hello")
+        .then()
+                .statusCode(200)
+                .body("content", is("Hello, Isaac!"));
+    }
+}

--- a/deployment-strategies/quarkus-serverless/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/QuarkusDeploymentStrategyOpenShiftServerlessIT.java
+++ b/deployment-strategies/quarkus-serverless/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/serverless/QuarkusDeploymentStrategyOpenShiftServerlessIT.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.openshift.deployment.strategies.quarkus.serverless;
+
+import io.fabric8.knative.client.KnativeClient;
+import io.quarkus.ts.openshift.common.Command;
+import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.CustomizeApplicationUndeployment;
+import io.quarkus.ts.openshift.common.ManualApplicationDeployment;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+@OpenShiftTest
+@ManualApplicationDeployment
+public class QuarkusDeploymentStrategyOpenShiftServerlessIT {
+
+    // S2I build is performed during application build, see quarkus.container-image.build property in the POM
+    // Deploy of the service is done as part of the test because current namespace needs to be reflected in the image name
+
+    @CustomizeApplicationDeployment
+    public static void deploy(KnativeClient kn) throws IOException, InterruptedException {
+        adjustKnativeYml(kn.getNamespace());
+        new Command("oc", "apply", "-f", "target/kubernetes/knative.yml").runAndWait();
+    }
+
+    @CustomizeApplicationUndeployment
+    public static void undeploy() throws IOException, InterruptedException {
+        new Command("oc", "delete", "-f", "target/kubernetes/knative.yml").runAndWait();
+    }
+
+    @Test
+    public void hello() {
+        when()
+                .get("/hello")
+        .then()
+                .statusCode(200)
+                .body("content", is("Hello, World!"));
+    }
+
+    private static void adjustKnativeYml(String currentNamespace) throws IOException {
+        Path yamlPath = Paths.get("target/kubernetes/knative.yml");
+        Charset charset = StandardCharsets.UTF_8;
+
+        String yamlContent = new String(Files.readAllBytes(yamlPath), charset);
+        yamlContent = yamlContent.replaceAll("to-be-replaced-by-current-namespace", currentNamespace);
+        Files.write(yamlPath, yamlContent.getBytes(charset));
+    }
+}

--- a/deployment-strategies/quarkus/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/QuarkusDeploymentStrategyOpenShiftIT.java
+++ b/deployment-strategies/quarkus/src/test/java/io/quarkus/ts/openshift/deployment/strategies/quarkus/QuarkusDeploymentStrategyOpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.deployment.strategies.quarkus;
 
 import io.quarkus.ts.openshift.common.Command;
+import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.CustomizeApplicationUndeployment;
 import io.quarkus.ts.openshift.common.ManualApplicationDeployment;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
@@ -12,7 +13,8 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.is;
 
 @OpenShiftTest
-@ManualApplicationDeployment(appName = "deployment-strategy-quarkus", httpRoot = "/", knownEndpoint = "/health/ready")
+@ManualApplicationDeployment
+@CustomAppMetadata(appName = "deployment-strategy-quarkus", httpRoot = "/", knownEndpoint = "/health/ready")
 public class QuarkusDeploymentStrategyOpenShiftIT {
     // deployment is performed by the Quarkus Kubernetes extension during application build,
     // because we set quarkus.kubernetes.deploy=true (see the POM)

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.heroes.workshop;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.ManualApplicationDeployment;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
@@ -25,7 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @OpenShiftTest
-@ManualApplicationDeployment(appName = "quarkus-workshop-hero", httpRoot = "/", knownEndpoint = "/")
+@ManualApplicationDeployment
+@CustomAppMetadata(appName = "quarkus-workshop-hero", httpRoot = "/", knownEndpoint = "/")
 @AdditionalResources("classpath:openjdk-11-rhel7.yaml")
 @AdditionalResources("classpath:heroes-database.yaml")
 @AdditionalResources("classpath:hero.yaml")

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.heroes.workshop;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.ManualApplicationDeployment;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
@@ -26,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @OpenShiftTest
-@ManualApplicationDeployment(appName = "quarkus-workshop-villain", httpRoot = "/", knownEndpoint = "/")
+@ManualApplicationDeployment
+@CustomAppMetadata(appName = "quarkus-workshop-villain", httpRoot = "/", knownEndpoint = "/")
 @AdditionalResources("classpath:openjdk-11-rhel7.yaml")
 @AdditionalResources("classpath:villains-database.yaml")
 @AdditionalResources("classpath:villain.yaml")

--- a/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
+++ b/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.todo.demo.app;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.ManualApplicationDeployment;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 import io.quarkus.ts.openshift.common.injection.TestResource;
@@ -11,7 +12,8 @@ import java.net.URL;
 import static io.restassured.RestAssured.when;
 
 @OpenShiftTest
-@ManualApplicationDeployment(appName = "todo-demo-app", httpRoot = "/", knownEndpoint = "/")
+@ManualApplicationDeployment
+@CustomAppMetadata(appName = "todo-demo-app", httpRoot = "/", knownEndpoint = "/")
 @AdditionalResources("classpath:openjdk-11-rhel7.yaml")
 @AdditionalResources("classpath:todo-demo-app.yaml")
 public class TodoDemoAppOpenShiftIT {

--- a/pom.xml
+++ b/pom.xml
@@ -258,9 +258,21 @@
 
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Alpha2-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Final-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
             </properties>
+        </profile>
+
+        <profile>
+            <id>serverless</id>
+            <activation>
+                <property>
+                    <name>include.serverless</name>
+                </property>
+            </activation>
+            <modules>
+                <module>deployment-strategies/quarkus-serverless</module>
+            </modules>
         </profile>
 
     </profiles>


### PR DESCRIPTION
OpenShift Serverless support in test framework, first test for OpenShift Serverless

See changes in README.md

Went ahead with dedicated profile because `@OnlyIfConfigured("ts.serverless")` approach wouldn't prevent execution of the S2I build during the `package` phase.
