### PR TITLE
Workaround for Quarkus issue #11968

### DIFF
--- a/config-secret/api-server/src/main/resources/application.properties
+++ b/config-secret/api-server/src/main/resources/application.properties
@@ -6,3 +6,5 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
 
 %test.hello.message=Hello, %s!
 %test.quarkus.kubernetes-config.enabled=false
+# TODO: remove once https://github.com/quarkusio/quarkus/issues/11968 is resolved
+%test.quarkus.kubernetes-config.secrets.enabled=false


### PR DESCRIPTION
Implementing a workaround for https://github.com/quarkusio/quarkus/issues/11968 where precedence of `quarkus.kubernetes-config.secrets.enabled` and `quarkus.kubernetes-config.enabled` changed.