### PR TITLE
Skipping messaging tests due to flakiness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,13 @@
         <module>configmap/file-system</module>
         <module>config-secret/api-server</module>
         <module>config-secret/file-system</module>
+        <!-- The messaging tests and integration tests are currently flaky and require investigation.
+             Disabling them until further notice.
         <module>messaging/artemis</module>
         <module>messaging/artemis-jta</module>
         <module>messaging/amqp-reactive</module>
         <module>messaging/qpid</module>
+	-->
         <module>scaling</module>
         <module>sql-db/app</module>
         <module>sql-db/postgresql</module>


### PR DESCRIPTION
Unit tests are failing in 1/5 Ci runs and integration tests are failing in 1/3 OpenShift runs.

Disabling the modules until they're properly investigated.

Tracking issue: #93 