### PR TITLE
Quarkus 1.9 updates for new datasource configuration

### DIFF
--- a/sql-db/app/src/test/resources/application.properties
+++ b/sql-db/app/src/test/resources/application.properties
@@ -2,7 +2,7 @@
 %test.quarkus.hibernate-orm.database.generation=drop-and-create
 %test.quarkus.hibernate-orm.sql-load-script=import.sql
 
-%test.quarkus.datasource.driver=org.h2.Driver
-%test.quarkus.datasource.url=jdbc:h2:mem:mydb
+%test.quarkus.datasource.db-kind=h2
+%test.quarkus.datasource.jdbc.url=jdbc:h2:mem:mydb
 %test.quarkus.datasource.username=sa
 %test.quarkus.datasource.password=sa

--- a/sql-db/mariadb/src/main/resources/application.properties
+++ b/sql-db/mariadb/src/main/resources/application.properties
@@ -8,11 +8,11 @@ quarkus.openshift.env-vars.DB_USERNAME.value=username
 quarkus.openshift.env-vars.DB_PASSWORD.secret=mariadb
 quarkus.openshift.env-vars.DB_PASSWORD.value=password
 
-quarkus.datasource.driver=org.mariadb.jdbc.Driver
-quarkus.datasource.url=jdbc:mysql://mariadb:3306/${DB_DATABASE}
+quarkus.datasource.db-kind=mariadb
+quarkus.datasource.jdbc.url=jdbc:mariadb://mariadb:3306/${DB_DATABASE}
 quarkus.datasource.username=${DB_USERNAME}
 quarkus.datasource.password=${DB_PASSWORD}
-#quarkus.datasource.url=jdbc:mysql://localhost:3306/mydb
+#quarkus.datasource.jdbc.url=jdbc:mariadb://localhost:3306/mydb
 #quarkus.datasource.username=mydb
 #quarkus.datasource.password=mydb
 

--- a/sql-db/mssql/src/main/resources/application.properties
+++ b/sql-db/mssql/src/main/resources/application.properties
@@ -8,11 +8,11 @@ quarkus.openshift.env-vars.DB_USERNAME.value=username
 quarkus.openshift.env-vars.DB_PASSWORD.secret=mssql
 quarkus.openshift.env-vars.DB_PASSWORD.value=password
 
-quarkus.datasource.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
-quarkus.datasource.url=jdbc:sqlserver://mssql:1433;databaseName=${DB_DATABASE}
+quarkus.datasource.db-kind=mssql
+quarkus.datasource.jdbc.url=jdbc:sqlserver://mssql:1433;databaseName=${DB_DATABASE}
 quarkus.datasource.username=${DB_USERNAME}
 quarkus.datasource.password=${DB_PASSWORD}
-#quarkus.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=mydb
+#quarkus.datasource.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=mydb
 #quarkus.datasource.username=sa
 #quarkus.datasource.password=My1337p@ssworD
 

--- a/sql-db/mysql/src/main/resources/application.properties
+++ b/sql-db/mysql/src/main/resources/application.properties
@@ -8,11 +8,11 @@ quarkus.openshift.env-vars.DB_USERNAME.value=username
 quarkus.openshift.env-vars.DB_PASSWORD.secret=mysql
 quarkus.openshift.env-vars.DB_PASSWORD.value=password
 
-quarkus.datasource.driver=com.mysql.cj.jdbc.Driver
-quarkus.datasource.url=jdbc:mysql://mysql:3306/${DB_DATABASE}
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.jdbc.url=jdbc:mysql://mysql:3306/${DB_DATABASE}
 quarkus.datasource.username=${DB_USERNAME}
 quarkus.datasource.password=${DB_PASSWORD}
-#quarkus.datasource.url=jdbc:mysql://localhost:3306/mydb
+#quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/mydb
 #quarkus.datasource.username=mydb
 #quarkus.datasource.password=mydb
 

--- a/sql-db/postgresql/src/main/resources/application.properties
+++ b/sql-db/postgresql/src/main/resources/application.properties
@@ -8,11 +8,11 @@ quarkus.openshift.env-vars.DB_USERNAME.value=username
 quarkus.openshift.env-vars.DB_PASSWORD.secret=postgresql
 quarkus.openshift.env-vars.DB_PASSWORD.value=password
 
-quarkus.datasource.driver=org.postgresql.Driver
-quarkus.datasource.url=jdbc:postgresql://postgresql:5432/${DB_DATABASE}
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql:5432/${DB_DATABASE}
 quarkus.datasource.username=${DB_USERNAME}
 quarkus.datasource.password=${DB_PASSWORD}
-#quarkus.datasource.url=jdbc:postgresql://localhost:5432/mydb
+#quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/mydb
 #quarkus.datasource.username=mydb
 #quarkus.datasource.password=mydb
 


### PR DESCRIPTION
Quarkus 1.9 updates for new datasource configuration

run: https://quarkus-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/openshift-test-suite-ci/25/

Just fyi:
`mvn clean verify -Pquarkus-core-only -pl sql-db/app/,sql-db/postgresql -Dversion.quarkus=1.8.2.Final` works

`mvn clean verify -Pquarkus-core-only -pl sql-db/app/,sql-db/postgresql -Dversion.quarkus=1.9.0.CR1` fails 
In logs on OCP I can see this:
```
Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
[0;31mERROR No such file /deployments/target/sql-db-postgresql-1.0.0-SNAPSHOT-runner.jar[0m
INFO exec  java ........
```
Feels like something changed on Quarkus side :/