### PR TITLE
prerequisites for updating to Quarkus 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build with Maven
@@ -44,7 +45,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build with Maven
@@ -65,7 +67,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build Quarkus master
@@ -94,7 +97,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build Quarkus master

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ This is configured in the `application.properties` file in each module.
 Since this is standard Quarkus configuration, it's possible to override using a system property.
 Therefore, if you want to run the tests with a different Java S2I image, run `mvn clean verify -Dquarkus.s2i.base-jvm-image=...`.
 
+### Other prerequisites
+
+In addition to common prerequisites for Java projects (JDK, Maven) and OpenShift (`oc`), the following utilities must also be installed on the machine where the test suite is being executed:
+
+- `tar`
+
 ## Running against Red Hat build of Quarkus
+
 When running against released Red Hat build of Quarkus make sure https://maven.repository.redhat.com/ga/ repository is defined in settings.xml.
 
 Example command for released Red Hat build of Quarkus:
@@ -34,6 +41,7 @@ mvn -fae clean verify \
 ```
 
 Example command for not yet released version of Red Hat build of Quarkus:
+
 ```
 mvn -fae clean verify \
  -Dts.use-ephemeral-namespaces -Dts.authenticated-registry \
@@ -43,6 +51,7 @@ mvn -fae clean verify \
 ```
 
 ## Branching Strategy
+
 The `master` branch is always meant for latest upstream/downstream development. For each downstream major.minor version, there's a corresponding maintenance branch:
 
   - `1.3` for Red Hat build of Quarkus 1.3.z (corresponding upstream version: `1.3.0.Final+`)

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.openshift.common.util;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.ResourceHandler;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.quarkus.ts.openshift.app.metadata.AppMetadata;
 import io.quarkus.ts.openshift.common.OpenShiftTestException;
@@ -50,7 +49,7 @@ public final class AwaitUtil {
 
     public void awaitReadiness(List<HasMetadata> resources) {
         resources.stream()
-                .filter(it -> Readiness.isReadinessApplicable(it.getClass()))
+                .filter(it -> ReadinessUtil.isReadinessApplicable(it.getClass()))
                 .forEach(it -> {
                     System.out.println(ansi().a("waiting for ").a(readableKind(it.getKind())).a(" ")
                             .fgYellow().a(it.getMetadata().getName()).reset().a(" to become ready"));
@@ -67,7 +66,7 @@ public final class AwaitUtil {
                             throw new OpenShiftTestException("Couldn't load " + readableKind(it.getKind()) + " '"
                                     + it.getMetadata().getName() + "' from API server");
                         }
-                        return Readiness.isReady(current);
+                        return ReadinessUtil.isReady(current);
                     });
                 });
     }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
@@ -1,7 +1,6 @@
 package io.quarkus.ts.openshift.common.util;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 import java.io.File;
@@ -59,7 +58,7 @@ public final class OpenShiftUtil {
             // but that's only available since OpenShift 3.5
             List<Pod> pods = listPodsForDeploymentConfig(deploymentConfigName);
             try {
-                return pods.size() == expectedReplicas && pods.stream().allMatch(Readiness::isPodReady);
+                return pods.size() == expectedReplicas && pods.stream().allMatch(ReadinessUtil::isPodReady);
             } catch (IllegalStateException e) {
                 // the 'Ready' condition can be missing sometimes, in which case Readiness.isPodReady throws an exception
                 // here, we'll swallow that exception in hope that the 'Ready' condition will appear later
@@ -73,7 +72,7 @@ public final class OpenShiftUtil {
 
         int number = 0;
         for (Pod pod : pods) {
-            if (Readiness.isPodReady(pod)) {
+            if (ReadinessUtil.isPodReady(pod)) {
                 number++;
             }
         }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/ReadinessUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/ReadinessUtil.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.openshift.common.util;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
+
+/**
+ * Unifies Fabric8 Kubernetes Client's {@link Readiness} and {@link OpenShiftReadiness}.
+ * No other class should refer to them directly; using {@code ReadinessUtil} is preferred.
+ */
+public class ReadinessUtil {
+    public static boolean isReadinessApplicable(Class<? extends HasMetadata> resourceClass) {
+        // unfortunately `OpenShiftReadiness` doesn't have a `isReadinessApplicable` method
+        return Readiness.isReadinessApplicable(resourceClass)
+                || DeploymentConfig.class.isAssignableFrom(resourceClass)
+                ;
+    }
+
+    public static boolean isReady(HasMetadata resource) {
+        // `OpenShiftReadiness.isReady` calls `Readiness.isReady` if it is a Kubernetes resource
+        return OpenShiftReadiness.isReady(resource);
+    }
+
+    public static boolean isPodReady(Pod pod) {
+        return Readiness.isPodReady(pod);
+    }
+}

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -23,7 +23,7 @@
           -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-s2i</artifactId>
+            <artifactId>quarkus-container-image-openshift</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This mainly means moving from `container-image-s2i` to
`container-image-openshift`. The `openshift` extension,
which used to bring `container-image-s2i`, now brings
`container-image-openshift`, so wherever we used to use
`container-image-s2i` explicitly (= the `http` test),
we now use `container-image-openshift` instead.

That mainly means one important change, which is largely
invisible to people who exclusively use Quarkus tooling:
the expectation now is that the application files are
present in `/deployments/target` in the container image.
Previously, they were in `/deployments`.

In addition to that, this commit also deals with one
change in Fabric8 Kubernetes Client: they have split
their `Readiness` class into two (Kubernetes-specific
and OpenShift-specific). As a response, this commit
adds `ReadinessUtil` which unifies that.