### PR TITLE
Enable messaging tests and fix amqp reactive test case

### DIFF
--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
@@ -36,7 +36,7 @@ public final class AwaitUtil {
     public void awaitAppRoute() {
         System.out.println(ansi().a("waiting for route ").fgYellow().a(metadata.appName).reset()
                 .a(" to start responding at ").fgYellow().a(metadata.knownEndpoint).reset());
-        await().atMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
+        await().ignoreExceptions().atMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
             given()
                     // known endpoint is already httpRoot-adjusted
                     .basePath("/")
@@ -53,7 +53,9 @@ public final class AwaitUtil {
                 .forEach(it -> {
                     System.out.println(ansi().a("waiting for ").a(readableKind(it.getKind())).a(" ")
                             .fgYellow().a(it.getMetadata().getName()).reset().a(" to become ready"));
-                    await().atMost(5, TimeUnit.MINUTES).until(() -> {
+                    await().pollInterval(1, TimeUnit.SECONDS)
+                           .atMost(5, TimeUnit.MINUTES)
+                           .until(() -> {
                         HasMetadata current = oc.resource(it).fromServer().get();
                         if (current == null) {
                             ResourceHandler<HasMetadata, ?> handler = Handlers.get(it.getKind(), it.getApiVersion());

--- a/messaging/amqp-reactive/src/main/resources/application.properties
+++ b/messaging/amqp-reactive/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
 
-# Configures the AMQP broker credentials.
-amqp-username=quarkus
-amqp-password=quarkus
 %test.amqp-host=localhost
 amqp-host=amq-broker-amqp
 amqp-port=5672

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/openshift/messaging/amqp/AbstractAMQPTest.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/openshift/messaging/amqp/AbstractAMQPTest.java
@@ -9,11 +9,17 @@ import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.when;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public abstract class AbstractAMQPTest {
 
+    /**
+     * The producer sends a price every 1 sec {@link io.quarkus.ts.openshift.messaging.amqp.PriceProducer#generate()}.
+     * Eventually, the consumer will get up to 10 prices (from 10 to 100) but it might receive more
+     * {@link io.quarkus.ts.openshift.messaging.amqp.PriceConsumer#process()}.
+     *
+     */
     @Test
     @Order(1)
     public void testLastPrice() {
@@ -23,6 +29,6 @@ public abstract class AbstractAMQPTest {
                         .get("/price")
                     .then()
                         .statusCode(200)
-                        .body(equalTo("[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]")));
+                        .body(containsString("10, 20, 30, 40, 50, 60, 70, 80, 90, 100")));
     }
 }

--- a/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ProducerService.java
+++ b/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ProducerService.java
@@ -31,7 +31,7 @@ public class ProducerService {
             LOG.info(customPrice + " sent to queue custom-prices-2");
             context.commit();
             context.acknowledge();
-             context.setAutoStart(true);
+            context.setAutoStart(true);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,10 @@
         <module>configmap/file-system</module>
         <module>config-secret/api-server</module>
         <module>config-secret/file-system</module>
-        <!-- The messaging tests and integration tests are currently flaky and require investigation.
-             Disabling them until further notice.
         <module>messaging/artemis</module>
         <module>messaging/artemis-jta</module>
         <module>messaging/amqp-reactive</module>
         <module>messaging/qpid</module>
-	-->
         <module>scaling</module>
         <module>sql-db/app</module>
         <module>sql-db/postgresql</module>


### PR DESCRIPTION
This PR will enable the messaging tests and fix the amqp-reactive module. Also:
- Fix await route util to ignore exceptions (sometimes it returns 503 Gateway Timeout because the route is not ready yet).
- Avoid to request for resources too often (it can cause too many requests exception -> this happens when the cluster is too busy)
- Create a messaging parent to include all the messaging modules.

See dependant issue: https://github.com/quarkus-qe/quarkus-openshift-test-suite/issues/93