### PR TITLE
Print pod logs for failed scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,14 @@ The following command will execute the whole test suite including serverless tes
 ./mvnw clean verify -Dinclude.serverless
 ```
 
+### OpenShift Pod Logs on Failures
+
+When a test fails, the test suite will copy the pod logs in order to troubleshoot the issue. These logs will be copied in the `[module]/target/logs/[namespace]` folder. We can configure the output folder using the `ts.instance-logs` property: 
+
+```
+./mvnw clean verify -Dts.instance-logs=../custom/path
+```
+
 ### TODO
 
 There's a lot of possible improvements that haven't been implemented yet.

--- a/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
@@ -2,16 +2,22 @@ package io.quarkus.ts.openshift.common;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static org.fusesource.jansi.Ansi.ansi;
 
 public class Command {
     private final String description;
     private final List<String> command;
+
+    private BiConsumer<String, InputStream> outputConsumer = consoleOutput();
 
     public Command(String... command) {
         this(Arrays.asList(command));
@@ -20,6 +26,16 @@ public class Command {
     public Command(List<String> command) {
         this.description = descriptionOfProgram(command.get(0));
         this.command = command;
+    }
+
+    public Command outputToFile(File file) {
+        outputConsumer = fileOutput(file);
+        return this;
+    }
+
+    public Command outputToConsole() {
+        outputConsumer = consoleOutput();
+        return this;
     }
 
     private static String descriptionOfProgram(String program) {
@@ -31,7 +47,6 @@ public class Command {
 
     public void runAndWait() throws IOException, InterruptedException {
         System.out.println(ansi().a("running ").fgYellow().a(String.join(" ", command)).reset());
-
         Process process = new ProcessBuilder()
                 .redirectErrorStream(true)
                 .command(command)
@@ -39,18 +54,37 @@ public class Command {
                 .start();
 
         new Thread(() -> {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    System.out.println(ansi().fgCyan().a(description).reset().a("> ").a(line));
-                }
-            } catch (IOException ignored) {
-            }
+            outputConsumer.accept(description, process.getInputStream());
         }, "stdout consumer for command " + description).start();
 
         int result = process.waitFor();
         if (result != 0) {
             throw new RuntimeException(description + " failed (executed " + command + ", return code " + result + ")");
         }
+    }
+
+    private static final BiConsumer<String, InputStream> fileOutput(File targetFile) {
+        return (description, is) -> {
+            try (OutputStream outStream = new FileOutputStream(targetFile)) {
+                byte[] buffer = new byte[8 * 1024];
+                int bytesRead;
+                while ((bytesRead = is.read(buffer)) != -1) {
+                    outStream.write(buffer, 0, bytesRead);
+                }
+            } catch (IOException ignored) {
+            }
+        };
+    }
+
+    private static final BiConsumer<String, InputStream> consoleOutput() {
+        return (description, is) -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(ansi().fgCyan().a(description).reset().a("> ").a(line));
+                }
+            } catch (IOException ignored) {
+            }
+        };
     }
 }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/actions/CopyLogsOnOpenShiftFailureActionImpl.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/actions/CopyLogsOnOpenShiftFailureActionImpl.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.openshift.common.actions;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.quarkus.ts.openshift.common.Command;
+import io.quarkus.ts.openshift.common.config.Config;
+import io.quarkus.ts.openshift.common.injection.TestResource;
+import io.quarkus.ts.openshift.common.util.OpenShiftUtil;
+
+import java.io.File;
+
+public class CopyLogsOnOpenShiftFailureActionImpl implements OnOpenShiftFailureAction {
+
+    private static final String INSTANCES_LOGS_OUTPUT_DIRECTORY = "ts.instance-logs";
+    private static final String DEFAULT_LOG_OUTPUT_DIRECTORY = "target/logs";
+    private static final String LOG_SUFFIX = ".log";
+
+    @TestResource
+    private OpenShiftUtil openShiftUtil;
+
+    @TestResource
+    private Config config;
+
+    @Override
+    public void execute() throws Exception {
+        String namespace = openShiftUtil.getNamespace();
+        for (Pod pod : openShiftUtil.getPods()) {
+            String podName = pod.getMetadata().getName();
+            new Command("oc", "logs", podName).outputToFile(getOutputFile(podName, namespace)).runAndWait();
+        }
+    }
+
+    private String getOutputFolder() {
+        return config.getAsString(INSTANCES_LOGS_OUTPUT_DIRECTORY, DEFAULT_LOG_OUTPUT_DIRECTORY);
+    }
+
+    private File getOutputFile(String name, String customLogFolderName) {
+        File outputDirectory = new File(getOutputFolder(), customLogFolderName);
+        outputDirectory.mkdirs();
+        return new File(outputDirectory, name + LOG_SUFFIX);
+    }
+
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/actions/OnOpenShiftFailureAction.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/actions/OnOpenShiftFailureAction.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.openshift.common.actions;
+
+/**
+ * Interface to perform an action after an OpenShift failure.
+ */
+public interface OnOpenShiftFailureAction {
+
+    /**
+     * Action to perform
+     * 
+     * @throws Exception to be logged
+     */
+    void execute() throws Exception;
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/actions/PrintStatusOnOpenShiftFailureActionImpl.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/actions/PrintStatusOnOpenShiftFailureActionImpl.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.openshift.common.actions;
+
+import io.quarkus.ts.openshift.common.Command;
+
+public class PrintStatusOnOpenShiftFailureActionImpl implements OnOpenShiftFailureAction {
+
+    @Override
+    public void execute() throws Exception {
+        new Command("oc", "status", "--suggest").runAndWait();
+    }
+
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
@@ -22,7 +22,15 @@ public final class OpenShiftUtil {
         this.await = await;
     }
 
-    private List<Pod> listPodsForDeploymentConfig(String deploymentConfigName) {
+    public String getNamespace() {
+        return oc.getNamespace();
+    }
+
+    public List<Pod> getPods() {
+        return oc.pods().list().getItems();
+    }
+
+    public List<Pod> listPodsForDeploymentConfig(String deploymentConfigName) {
         return oc.pods()
                 .inNamespace(oc.getNamespace())
                 .withLabel("deploymentconfig", deploymentConfigName)

--- a/common/src/main/resources/META-INF/services/io.quarkus.ts.openshift.common.actions.OnOpenShiftFailureAction
+++ b/common/src/main/resources/META-INF/services/io.quarkus.ts.openshift.common.actions.OnOpenShiftFailureAction
@@ -1,0 +1,2 @@
+io.quarkus.ts.openshift.common.actions.PrintStatusOnOpenShiftFailureActionImpl
+io.quarkus.ts.openshift.common.actions.CopyLogsOnOpenShiftFailureActionImpl


### PR DESCRIPTION
Changes:
- Allow to configure the command to specify the output (whether a file or the console)
- Update OpenShiftTestExtension to run a list of actions when a scenario fails
- Add two actions to be run after a scenario failure: CopyLogsOnOpenShiftFailureActionImpl and PrintStatusOnOpenShiftFailureActionImpl.