### PR TITLE
Fix Artemis test issue

### DIFF
--- a/messaging/artemis-jta/pom.xml
+++ b/messaging/artemis-jta/pom.xml
@@ -83,6 +83,15 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>

--- a/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ConsumerService.java
+++ b/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ConsumerService.java
@@ -1,8 +1,6 @@
 package io.quarkus.ts.openshift.messaging.artemisjta;
 
-import io.quarkus.scheduler.Scheduled;
-import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
-
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -14,8 +12,6 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 
-import java.util.function.Consumer;
-
 @ApplicationScoped
 public class ConsumerService {
 
@@ -24,37 +20,17 @@ public class ConsumerService {
     @Inject
     ConnectionFactory connectionFactory;
 
-    private volatile String price1 = "dead";
-    private volatile String price2 = "dead";
-
-    /*
-    Why empty getter and setter? CDI proxy...
-    */
-    public String getPrice() {
-        return price1 + ":" + price2;
+    public String readPriceOne() {
+        return receiveMessagesInQueue("custom-prices-1");
     }
 
-    public void setPrice1(String price) {
-        this.price1 = price;
-    }
-
-    public void setPrice2(String price) {
-        this.price2 = price;
-    }
-
-    @Scheduled(every = "1s", concurrentExecution = ConcurrentExecution.SKIP)
-    public void receiveMessagesInCustomPriceOne() throws JMSException {
-        receiveMessagesInQueue("custom-prices-1", this::setPrice1);
-    }
-
-    @Scheduled(every = "1s", concurrentExecution = ConcurrentExecution.SKIP)
-    public void receiveMessagesInCustomPriceTwo() throws JMSException {
-        receiveMessagesInQueue("custom-prices-2", this::setPrice2);
+    public String readPriceTwo() {
+        return receiveMessagesInQueue("custom-prices-2");
     }
 
     public String receiveAndAck(boolean ackIt) throws JMSException {
-        try (JMSContext context = connectionFactory.createContext(Session.CLIENT_ACKNOWLEDGE)) {
-            JMSConsumer consumer = context.createConsumer(context.createQueue("custom-prices-cack"));
+        try (JMSContext context = connectionFactory.createContext(Session.CLIENT_ACKNOWLEDGE);
+                JMSConsumer consumer = context.createConsumer(context.createQueue("custom-prices-cack"))) {
             Message message = consumer.receiveNoWait();
             String messageBody = (message != null) ? message.getBody(String.class) : "";
             if (ackIt) {
@@ -64,17 +40,21 @@ public class ConsumerService {
         }
     }
 
-    private void receiveMessagesInQueue(String queueName, Consumer<String> setter) throws JMSException {
-        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE)) {
-            JMSConsumer consumer = context.createConsumer(context.createQueue(queueName));
+    private String receiveMessagesInQueue(String queueName) {
+        String price = StringUtils.EMPTY;
+        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE);
+                JMSConsumer consumer = context.createConsumer(context.createQueue(queueName))) {
             Message message = consumer.receive(500);
             if (message != null) {
-                String price = message.getBody(String.class);
-                setter.accept(price);
+                price = message.getBody(String.class);
                 LOG.info("Price set to " + price + " from " + queueName);
             } else {
                 LOG.info("Nothing to see in queue " + queueName);
             }
+        } catch (JMSException ex) {
+            LOG.error("Error reading queue. ", ex);
         }
+
+        return price;
     }
 }

--- a/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ProducerService.java
+++ b/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ProducerService.java
@@ -13,14 +13,16 @@ import javax.transaction.Transactional;
 @ApplicationScoped
 public class ProducerService {
 
+    private static final Logger LOG = Logger.getLogger(ProducerService.class.getName());
+
     @Inject
     ConnectionFactory connectionFactory;
-
-    private static final Logger LOG = Logger.getLogger(ProducerService.class.getName());
 
     @Transactional
     public void produceCustomPrice(String customPrice, boolean fail) {
         try (JMSContext context = connectionFactory.createContext(Session.SESSION_TRANSACTED)) {
+            context.setAutoStart(true);
+            context.acknowledge();
             JMSProducer p = context.createProducer();
             p.send(context.createQueue("custom-prices-1"), customPrice);
             LOG.info(customPrice + " sent to queue custom-prices-1");
@@ -28,10 +30,8 @@ public class ProducerService {
                 throw new IllegalStateException("Bad hair day");
             }
             p.send(context.createQueue("custom-prices-2"), customPrice);
-            LOG.info(customPrice + " sent to queue custom-prices-2");
             context.commit();
-            context.acknowledge();
-            context.setAutoStart(true);
+            LOG.info(customPrice + " sent to queue custom-prices-2");
         }
     }
 

--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -7,5 +7,5 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
 
 %test.quarkus.artemis.url=tcp://localhost:61616
 
-quarkus.transaction-manager.default-transaction-timeout=30s
+quarkus.transaction-manager.default-transaction-timeout=5s
 quarkus.transaction-manager.node-name=artemis-666

--- a/messaging/artemis-jta/src/test/resources/broker.xml
+++ b/messaging/artemis-jta/src/test/resources/broker.xml
@@ -4,6 +4,7 @@
         <paging-directory>./target/artemis/paging</paging-directory>
         <bindings-directory>./target/artemis/bindings</bindings-directory>
         <journal-directory>./target/artemis/journal</journal-directory>
+        <journal-compact-min-files>0</journal-compact-min-files>
         <large-messages-directory>./target/artemis/large-messages</large-messages-directory>
         <max-disk-usage>100</max-disk-usage>
         <connectors>

--- a/messaging/artemis/src/main/java/io/quarkus/ts/openshift/messaging/artemis/PriceConsumer.java
+++ b/messaging/artemis/src/main/java/io/quarkus/ts/openshift/messaging/artemis/PriceConsumer.java
@@ -1,10 +1,6 @@
 package io.quarkus.ts.openshift.messaging.artemis;
 
-import io.quarkus.runtime.ShutdownEvent;
-import io.quarkus.runtime.StartupEvent;
-
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSConsumer;
@@ -12,45 +8,26 @@ import javax.jms.JMSContext;
 import javax.jms.Message;
 import javax.jms.Session;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 /**
  * A bean consuming prices from the JMS queue.
  */
 @ApplicationScoped
-public class PriceConsumer implements Runnable {
+public class PriceConsumer {
 
     @Inject
     ConnectionFactory connectionFactory;
 
-    private final ExecutorService scheduler = Executors.newSingleThreadExecutor();
-
-    private volatile String lastPrice;
-
     public String getLastPrice() {
-        return lastPrice;
-    }
-
-    void onStart(@Observes StartupEvent ev) {
-        scheduler.submit(this);
-    }
-
-    void onStop(@Observes ShutdownEvent ev) {
-        scheduler.shutdown();
-    }
-
-    @Override
-    public void run() {
-        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE)) {
-            JMSConsumer consumer = context.createConsumer(context.createQueue("prices"));
+        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE);
+                JMSConsumer consumer = context.createConsumer(context.createQueue("prices"))) {
             while (true) {
                 Message message = consumer.receive();
                 if (message == null) {
                     // receive returns `null` if the JMSConsumer is closed
-                    return;
+                    return "";
                 }
-                lastPrice = message.getBody(String.class);
+
+                return message.getBody(String.class);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/messaging/artemis/src/main/java/io/quarkus/ts/openshift/messaging/artemis/PriceProducer.java
+++ b/messaging/artemis/src/main/java/io/quarkus/ts/openshift/messaging/artemis/PriceProducer.java
@@ -5,7 +5,6 @@ import io.quarkus.runtime.StartupEvent;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
-import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSContext;
 import javax.jms.Session;
@@ -21,14 +20,14 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 public class PriceProducer implements Runnable {
 
-    @Inject
-    ConnectionFactory connectionFactory;
-
     private final Random random = new Random();
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
-    void onStart(@Observes StartupEvent ev) {
-        scheduler.scheduleWithFixedDelay(this, 0L, 1L, TimeUnit.SECONDS);
+    private ConnectionFactory connectionFactory;
+
+    void onStart(@Observes StartupEvent ev, ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+        this.scheduler.scheduleWithFixedDelay(this, 0L, 1L, TimeUnit.SECONDS);
     }
 
     void onStop(@Observes ShutdownEvent ev) {


### PR DESCRIPTION
The issue is that the instance of ArtemisJmsProducer does not have the config injected when the scheduled job is invoked.
These changes try to address this issue by getting the same instance when observing the start event.

It also tries to fix a possible transaction timeout issue in the artemis-jta module.