### PR TITLE
Drop build-master-native from CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,27 +82,3 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-jvm${{ matrix.java }}.zip
-  build-master-native:
-    name: Native build - Quarkus master
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
-        with:
-          java-version: openjdk${{ matrix.java }}
-      - name: Build Quarkus master
-        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs -DskipDocs
-      - name: Build with Maven
-        run: |
-          mvn -fae -V -B clean install -Dquarkus-core-only -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker


### PR DESCRIPTION
Drop build-master-native from CI run as Quarkus master build fails quite often because of connection reset aka maven central probably doesn't like so extensive pulls.

There is still native run with released version and full jvm run with both released version and quarkus master