### PR TITLE
Update joschi/setup-jdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build with Maven
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build with Maven
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build Quarkus master


### PR DESCRIPTION
Update joschi/setup-jdk to avoid GH Action errors like https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/111/checks?check_run_id=1410634310