### PR TITLE
Implement SSO + WebApp scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,15 @@ Authorization is based on URL patterns, and Keycloak is used for defining and en
 
 A simple Keycloak realm with 1 client (protected application), 2 users, 2 roles and 2 protected resources is provided in `test-realm.json`.
 
+### `security/keycloak-webapp`
+
+Verifies authorization code flow and role-based authentication to protect web applications.
+Authentication is OIDC, and Keycloak is used for granting user access via login form.
+Authorization is based on roles, which are configured in Keycloak.
+Restrictions are defined using common annotations (`@RolesAllowed` etc.).
+
+A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.
+
 ### `security/https-1way`
 
 Verifies that accessing an HTTPS endpoint is posible.

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>security/jwt</module>
         <module>security/keycloak</module>
         <module>security/keycloak-authz</module>
+        <module>security/keycloak-webapp</module>
         <module>security/https-1way</module>
         <module>security/https-2way</module>
         <module>security/https-2way-authz</module>
@@ -67,6 +68,7 @@
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
         <version.quarkus>1.10.2.Final</version.quarkus>
+        <version.testcontainers>1.15.0</version.testcontainers>
     </properties>
 
     <dependencyManagement>
@@ -75,6 +77,14 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${version.quarkus}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${version.testcontainers}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/security/keycloak-webapp/.dockerignore
+++ b/security/keycloak-webapp/.dockerignore
@@ -1,0 +1,4 @@
+*
+!target/*-runner
+!target/*-runner.jar
+!target/lib/*

--- a/security/keycloak-webapp/pom.xml
+++ b/security/keycloak-webapp/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>security-keycloak-webapp</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Security: Keycloak Authentication + Web</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>app-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/security/keycloak-webapp/src/main/docker/Dockerfile.jvm
+++ b/security/keycloak-webapp/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,54 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+# 
+# Then run the container using : 
+#
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/security/keycloak-webapp/src/main/docker/Dockerfile.native
+++ b/security/keycloak-webapp/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/security/keycloak-webapp/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
+++ b/security/keycloak-webapp/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/admin")
+@RolesAllowed("test-admin-role")
+public class AdminResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    JsonWebToken jwt;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, admin " + identity.getPrincipal().getName();
+    }
+
+    @GET
+    @Path("/issuer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String issuer() {
+        return "admin token issued by " + jwt.getIssuer();
+    }
+}

--- a/security/keycloak-webapp/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
+++ b/security/keycloak-webapp/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/user")
+@RolesAllowed("test-user-role")
+public class UserResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    JsonWebToken jwt;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+
+    @GET
+    @Path("/issuer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String issuer() {
+        return "user token issued by " + jwt.getIssuer();
+    }
+}

--- a/security/keycloak-webapp/src/main/resources/application.properties
+++ b/security/keycloak-webapp/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+# this will be overridden by an env var when deployed to OpenShift,
+# see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.client-id=test-application-client
+quarkus.oidc.credentials.secret=test-application-client-secret
+# tolerate 1 minute of clock skew between the Keycloak server and the application
+quarkus.oidc.token.lifespan-grace=60
+quarkus.oidc.application-type=web-app
+quarkus.oidc.roles.source=accesstoken
+quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.policy=authenticated
+
+quarkus.openshift.expose=true
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.ts.openshift.app.metadata.AppMetadata;
+import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.injection.TestResource;
+import io.quarkus.ts.openshift.common.injection.WithName;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
+
+    static String keycloakUrl;
+
+    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
+    @CustomizeApplicationDeployment
+    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
+            throws IOException {
+        keycloakUrl = url + "/auth/realms/test-realm";
+
+        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
+        objs.stream()
+                .filter(it -> it instanceof DeploymentConfig)
+                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
+                .map(DeploymentConfig.class::cast)
+                .forEach(dc -> {
+                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
+                        container.getEnv().add(
+                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null));
+                    });
+                });
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
+    }
+
+    @TestResource
+    private URL applicationUrl;
+
+    @Override
+    protected String getAuthServerUrl() {
+        return keycloakUrl;
+    }
+
+    @Override
+    protected String getAppUrl() {
+        return applicationUrl.toString();
+    }
+}

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class AbstractSecurityKeycloakOpenShiftTest {
+
+    private static final String REALM = "test-realm";
+
+    protected abstract String getAuthServerUrl();
+
+    protected abstract String getAppUrl();
+
+    private WebClient webClient;
+    private Page page;
+
+    @BeforeEach
+    public void setup() {
+        webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        webClient.getOptions().setRedirectEnabled(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Optional.ofNullable(webClient).ifPresent(WebClient::close);
+    }
+
+    @Test
+    public void verifyLocationHeader() throws Exception {
+        webClient.getOptions().setRedirectEnabled(false);
+        String loc = webClient.loadWebResponse(new WebRequest(URI.create(getAppUrl() + "/user").toURL()))
+                .getResponseHeaderValue("location");
+
+        assertTrue(loc.startsWith(getAuthServerUrl() + "/protocol/openid-connect/auth"));
+        assertTrue(loc.contains("scope=openid"));
+        assertTrue(loc.contains("response_type=code"));
+        assertTrue(loc.contains("client_id=test-application-client"));
+    }
+
+    @Test
+    public void normalUser_userResource() throws Exception {
+        whenGoTo("/user");
+        thenRedirectToLoginPage();
+
+        whenLoginAs("test-user");
+        thenPageReturns("Hello, user test-user");
+    }
+
+    @Test
+    public void normalUser_userResource_issuer() throws Exception {
+        whenGoTo("/user/issuer");
+        thenRedirectToLoginPage();
+
+        whenLoginAs("test-user");
+        thenPageReturns("user token issued by " + getAuthServerUrl());
+    }
+
+    @Test
+    public void normalUser_adminResource() throws Exception {
+        whenGoTo("/admin");
+        thenRedirectToLoginPage();
+
+        thenReturnsForbiddenWhenLoginAs("test-user");
+    }
+
+    @Test
+    public void adminUser_userResource() throws Exception {
+        whenGoTo("/user");
+        thenRedirectToLoginPage();
+
+        whenLoginAs("test-admin");
+        thenPageReturns("Hello, user test-admin");
+    }
+
+    @Test
+    public void adminUser_adminResource() throws Exception {
+        whenGoTo("/admin");
+        thenRedirectToLoginPage();
+
+        whenLoginAs("test-admin");
+        thenPageReturns("Hello, admin test-admin");
+    }
+
+    @Test
+    public void adminUser_adminResource_issuer() throws Exception {
+        whenGoTo("/admin/issuer");
+        thenRedirectToLoginPage();
+
+        whenLoginAs("test-admin");
+        thenPageReturns("admin token issued by " + getAuthServerUrl());
+    }
+
+    private void whenLoginAs(String user) throws Exception {
+        assertTrue(page instanceof HtmlPage, "Should be in an HTML page");
+        HtmlForm loginForm = ((HtmlPage) page).getForms().get(0);
+
+        loginForm.getInputByName("username").setValueAttribute(user);
+        loginForm.getInputByName("password").setValueAttribute(user);
+
+        page = loginForm.getInputByName("login").click();
+    }
+
+    private void whenGoTo(String path) throws Exception {
+        page = webClient.getPage(getAppUrl() + path);
+    }
+
+    private void thenRedirectToLoginPage() {
+        assertTrue(page instanceof HtmlPage, "Should be in the Login page");
+        assertEquals("Log in to " + REALM, ((HtmlPage) page).getTitleText(),
+                "Login page title should display application realm");
+    }
+
+    private void thenPageReturns(String expectedContent) {
+        assertTrue(page instanceof TextPage, "Should be in a text content page");
+        assertEquals(expectedContent, ((TextPage) page).getContent(), "Page content should match with expected content");
+    }
+
+    private void thenReturnsForbiddenWhenLoginAs(String user) {
+        FailingHttpStatusCodeException exception = assertThrows(FailingHttpStatusCodeException.class,
+                () -> whenLoginAs(user), "Should return HTTP status exception");
+        assertEquals(HttpStatus.SC_FORBIDDEN, exception.getStatusCode());
+    }
+}

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfNotConfigured("ts.authenticated-registry")
+public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfConfigured("ts.authenticated-registry")
+public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.ts.openshift.security.keycloak.containers.KeycloakQuarkusTestResource;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@QuarkusTest
+@QuarkusTestResource(KeycloakQuarkusTestResource.class)
+public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenShiftTest {
+
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    String oidcAuthServerUrl;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer appPort;
+
+    @Override
+    protected String getAppUrl() {
+        return "http://localhost:" + appPort;
+    }
+
+    @Override
+    protected String getAuthServerUrl() {
+        return oidcAuthServerUrl;
+    }
+}

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/containers/KeycloakQuarkusTestResource.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/containers/KeycloakQuarkusTestResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.ts.openshift.security.keycloak.containers;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class KeycloakQuarkusTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String OIDC_AUTH_URL_PROPERTY = "quarkus.oidc.auth-server-url";
+
+    private static final String USER = "admin";
+    private static final String PASSWORD = "admin";
+    private static final String REALM = "test-realm";
+    private static final int PORT = 8080;
+
+    private static final String REALM_FILE = "/tmp/realm.json";
+    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:11.0.3";
+
+    private GenericContainer<?> container;
+
+    @SuppressWarnings("resource")
+    @Override
+    public Map<String, String> start() {
+
+        container = new GenericContainer<>(KEYCLOAK_IMAGE)
+                .withEnv("KEYCLOAK_USER", USER)
+                .withEnv("KEYCLOAK_PASSWORD", PASSWORD)
+                .withEnv("KEYCLOAK_IMPORT", REALM_FILE)
+                .withClasspathResourceMapping("test-realm.json", REALM_FILE, BindMode.READ_ONLY)
+                .waitingFor(Wait.forHttp("/auth").withStartupTimeout(Duration.ofMinutes(5)));
+        container.addExposedPort(PORT);
+        container.start();
+
+        return Collections.singletonMap(OIDC_AUTH_URL_PROPERTY, oidcAuthUrl());
+    }
+
+    @Override
+    public void stop() {
+        Optional.ofNullable(container).ifPresent(GenericContainer::stop);
+    }
+
+    private String oidcAuthUrl() {
+        return String.format("http://localhost:%s/auth/realms/%s", container.getMappedPort(PORT), REALM);
+    }
+
+}

--- a/security/keycloak-webapp/src/test/resources/keycloak-realm.yaml
+++ b/security/keycloak-webapp/src/test/resources/keycloak-realm.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+data:
+  test-realm.json: |
+    {
+      "realm": "test-realm",
+      "enabled": true,
+      "sslRequired": "none",
+      "roles": {
+        "realm": [
+          {
+            "name": "test-user-role"
+          },
+          {
+            "name": "test-admin-role"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "test-user",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-user"
+            }
+          ],
+          "realmRoles": [
+            "test-user-role"
+          ]
+        },
+        {
+          "username": "test-admin",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-admin"
+            }
+          ],
+          "realmRoles": [
+            "test-user-role",
+            "test-admin-role"
+          ]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "test-application-client",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "test-application-client-secret",
+          "redirectUris": [
+            "*"
+          ]
+        }
+      ]
+    }

--- a/security/keycloak-webapp/src/test/resources/test-realm.json
+++ b/security/keycloak-webapp/src/test/resources/test-realm.json
@@ -1,0 +1,59 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "test-user-role"
+      },
+      {
+        "name": "test-admin-role"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-user"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role"
+      ]
+    },
+    {
+      "username": "test-admin",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-admin"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role",
+        "test-admin-role"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret",
+      "redirectUris": [
+        "*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is the same example as in SSO + Keycloak, but using a webapp application (`quarkus.oidc.application-type=web-app`).