### PR TITLE
Use Google mirror when building Quarkus master to avoid connection reset from central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           java-version: openjdk${{ matrix.java }}
       - name: Build Quarkus master
-        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs -DskipDocs
+        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -DskipTests -DskipITs -DskipDocs
       - name: Build with Maven
         run: mvn -fae -V -B clean test -Dquarkus-core-only -Dinclude.serverless
       - name: Zip Artifacts


### PR DESCRIPTION
Use Google mirror when building Quarkus master to avoid connection reset from central.

Lately quite a lot of GH action runs failed because of connection reset received from central, Quarkus team is using google mirror.