### PR TITLE
Await deployment readiness before awaiting route response for 1.7 branch

### DIFF
--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
@@ -8,7 +8,9 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.quarkus.ts.openshift.app.metadata.AppMetadata;
 import io.quarkus.ts.openshift.common.OpenShiftTestException;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +37,13 @@ public final class AwaitUtil {
     }
 
     public void awaitAppRoute() {
+        // if the route responds with 200, that should imply readiness
+        // unfortunately, with OpenShift 4.6, that doesn't seem to be the case :-/
+        awaitReadiness(Arrays.asList(
+                oc.deploymentConfigs().withName(metadata.appName).get(),
+                oc.apps().deployments().withName(metadata.appName).get()
+        ));
+
         System.out.println(ansi().a("waiting for route ").fgYellow().a(metadata.appName).reset()
                 .a(" to start responding at ").fgYellow().a(metadata.knownEndpoint).reset());
         await().atMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
@@ -50,6 +59,7 @@ public final class AwaitUtil {
 
     public void awaitReadiness(List<HasMetadata> resources) {
         resources.stream()
+                .filter(Objects::nonNull)
                 .filter(it -> Readiness.isReadinessApplicable(it.getClass()))
                 .forEach(it -> {
                     System.out.println(ansi().a("waiting for ").a(readableKind(it.getKind())).a(" ")


### PR DESCRIPTION
Await deployment readiness before awaiting route response for 1.7 branch based on https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/129/commits/718fa1a62e3903eb104239a44c2c525d4176ff61