### PR TITLE
Update legacy property format QUAKRUS_DATABASE_URL to the new QUARKUS_DATABASE_JDBC_URL

### DIFF
--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -56,7 +56,7 @@ items:
           env:
           - name: ARTIFACT_COPY_ARGS
             value: -p -r lib/ *-runner.jar
-          - name: QUARKUS_DATASOURCE_URL
+          - name: QUARKUS_DATASOURCE_JDBC_URL
             value: jdbc:postgresql://heroes-database:5432/heroes-database
           - name: QUARKUS_HTTP_PORT
             value: "8080"

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -56,7 +56,7 @@ items:
               env:
                 - name: ARTIFACT_COPY_ARGS
                   value: -p -r lib/ *-runner.jar
-                - name: QUARKUS_DATASOURCE_URL
+                - name: QUARKUS_DATASOURCE_JDBC_URL
                   value: jdbc:postgresql://villains-database:5432/villains-database
                 - name: QUARKUS_HTTP_PORT
                   value: "8080"


### PR DESCRIPTION
Quarkus 1.9 removed legacy JDBC URL format and now QUARKUS_DATASOURCE_URL no longer works. QUARKUS_DATASOURCE_JDBC_URL property must be set.