### PR TITLE
[1.7] Enable fallback test in microprofile module

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,6 @@ All HTTP endpoints and internal processing is asynchronous, so Context Propagati
 JAX-RS endpoints and RestClient calls are automatically traced with OpenTracing, and some additional logging into the OpenTracing spans is also done.
 Jaeger is deployed in an "all-in-one" configuration, and the OpenShift test verifies the stored traces.
 
-Note that the Fault Tolerance annotations are currently commented out, because of https://github.com/quarkusio/quarkus/issues/8650.
-This is a RESTEasy bug, there is a proposed fix: https://github.com/resteasy/Resteasy/pull/2359
-
 ### `messaging/artemis`
 
 Verifies that JMS server is up and running and Quarkus can communicate with this service.

--- a/microprofile/src/main/java/io/quarkus/ts/openshift/microprofile/HelloClient.java
+++ b/microprofile/src/main/java/io/quarkus/ts/openshift/microprofile/HelloClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.openshift.microprofile;
 
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import javax.ws.rs.GET;
@@ -16,11 +18,8 @@ public interface HelloClient {
     @GET
     @Path("/hello")
     @Produces(MediaType.TEXT_PLAIN)
-    // commented out because of https://github.com/quarkusio/quarkus/issues/8650
-/*
     @Asynchronous
     @Fallback(fallbackMethod = "fallback")
-*/
     CompletionStage<String> get();
 
     default CompletionStage<String> fallback() {

--- a/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/AbstractMicroProfileTest.java
+++ b/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/AbstractMicroProfileTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.openshift.microprofile;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,6 @@ public abstract class AbstractMicroProfileTest {
 
     @Test
     @Order(10)
-    @Disabled("https://github.com/quarkusio/quarkus/issues/8650")
     public void fallback() {
         when()
                 .post("/hello/disable")


### PR DESCRIPTION
Enable fallback test in microprofile module

`mvn clean verify -pl .,app-metadata/runtime,app-metadata/deployment,common,microprofile -Dversion.quarkus=1.7.5.Final`
gives expected
`[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 480.737 s - in io.quarkus.ts.openshift.microprofile.MicroProfileOpenShiftIT`