### PR TITLE
[1.7] Switch to quay.io/jaegertracing/all-in-one:1.21.0 to prevent pull limits from DockerHub

### DIFF
--- a/microprofile/src/main/resources/application.properties
+++ b/microprofile/src/main/resources/application.properties
@@ -10,4 +10,4 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
 
 %test.io.quarkus.ts.openshift.microprofile.HelloClient/mp-rest/url=http://localhost:8081/
 %test.quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces
-# docker run -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 jaegertracing/all-in-one:latest
+# docker run -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 quay.io/jaegertracing/all-in-one:1.21.0

--- a/microprofile/src/test/resources/jaeger-all-in-one-template.yml
+++ b/microprofile/src/test/resources/jaeger-all-in-one-template.yml
@@ -46,7 +46,7 @@ items:
           -   env:
               - name: COLLECTOR_ZIPKIN_HTTP_PORT
                 value: "9411"
-              image: jaegertracing/all-in-one
+              image: quay.io/jaegertracing/all-in-one:1.21.0
               name: jaeger
               ports:
                 - containerPort: 5775


### PR DESCRIPTION
Switch to quay.io/jaegertracing/all-in-one:1.21.0 to prevent pull limits from DockerHub

Verified with `mvn clean verify -pl .,app-metadata/runtime,app-metadata/deployment,common,microprofile` command