### PR TITLE
Implement SSO + OAUTH2 scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,13 @@ Restrictions are defined using common annotations (`@RolesAllowed` etc.).
 
 A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.
 
+### `security/keycloak-oauth2`
+
+Verifies authorization using OAuth2 protocol. Keycloak is used for issuing and verifying tokens.
+Restrictions are defined using common annotations (`@RolesAllowed` etc.).
+
+A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.
+
 ### `security/https-1way`
 
 Verifies that accessing an HTTPS endpoint is posible.

--- a/common/src/main/java/io/quarkus/ts/openshift/common/resources/KeycloakQuarkusTestResource.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/resources/KeycloakQuarkusTestResource.java
@@ -15,6 +15,7 @@ public class KeycloakQuarkusTestResource implements QuarkusTestResourceLifecycle
 
     private static final String OIDC_AUTH_URL_PROPERTY = "quarkus.oidc.auth-server-url";
     private static final String OIDC_TOKEN_ISSUER_PROPERTY = "quarkus.oidc.token.issuer";
+    private static final String OAUTH2_INTROSPECTION_URL_PROPERTY = "quarkus.oauth2.introspection-url";
 
     private static final String USER = "admin";
     private static final String PASSWORD = "admin";
@@ -51,14 +52,18 @@ public class KeycloakQuarkusTestResource implements QuarkusTestResourceLifecycle
         return Collections.emptyMap();
     }
 
-    protected String oidcAuthUrl() {
+    protected String realmAuthUrl() {
         return String.format("http://localhost:%s/auth/realms/%s", container.getMappedPort(PORT), REALM);
+    }
+
+    protected String tokenInstrospectUrl() {
+        return String.format("%s/protocol/openid-connect/token/introspect", realmAuthUrl());
     }
 
     public static class WithOidcConfig extends KeycloakQuarkusTestResource {
         @Override
         protected Map<String, String> providesQuarkusConfiguration() {
-            return Collections.singletonMap(OIDC_AUTH_URL_PROPERTY, oidcAuthUrl());
+            return Collections.singletonMap(OIDC_AUTH_URL_PROPERTY, realmAuthUrl());
         }
     }
 
@@ -66,8 +71,15 @@ public class KeycloakQuarkusTestResource implements QuarkusTestResourceLifecycle
         @Override
         protected Map<String, String> providesQuarkusConfiguration() {
             Map<String, String> properties = new HashMap<>(super.providesQuarkusConfiguration());
-            properties.put(OIDC_TOKEN_ISSUER_PROPERTY, oidcAuthUrl());
+            properties.put(OIDC_TOKEN_ISSUER_PROPERTY, realmAuthUrl());
             return properties;
+        }
+    }
+
+    public static class WithOAuth2Config extends KeycloakQuarkusTestResource {
+        @Override
+        protected Map<String, String> providesQuarkusConfiguration() {
+            return Collections.singletonMap(OAUTH2_INTROSPECTION_URL_PROPERTY, tokenInstrospectUrl());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>security/keycloak-authz</module>
         <module>security/keycloak-webapp</module>
         <module>security/keycloak-jwt</module>
+        <module>security/keycloak-oauth2</module>
         <module>security/https-1way</module>
         <module>security/https-2way</module>
         <module>security/https-2way-authz</module>

--- a/security/README.md
+++ b/security/README.md
@@ -78,3 +78,4 @@ Finally, the Keycloak test resource can be used to auto-configure the Quarkus ap
 
 - Using `KeycloakQuarkusTestResource.WithOidcConfig` to configure the OIDC Auth Url property.
 - Using `KeycloakQuarkusTestResource.WithOidcAndTokenIssuerConfig` to configure the OIDC Auth Url and the Token Issuer properties.
+- Using `KeycloakQuarkusTestResource.WithOAuth2Config` to configure the OAuth 2 Introspection Url.

--- a/security/keycloak-oauth2/pom.xml
+++ b/security/keycloak-oauth2/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>security-keycloak-oauth2</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Security: Keycloak Authentication + OAuth2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>app-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-authz-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/security/keycloak-oauth2/src/main/docker/Dockerfile.jvm
+++ b/security/keycloak-oauth2/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,54 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+# 
+# Then run the container using : 
+#
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/security/keycloak-oauth2/src/main/docker/Dockerfile.native
+++ b/security/keycloak-oauth2/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/security/keycloak-oauth2/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
+++ b/security/keycloak-oauth2/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/admin")
+@RolesAllowed("test-admin-role")
+public class AdminResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, admin " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oauth2/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
+++ b/security/keycloak-oauth2/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/user")
+@RolesAllowed("test-user-role")
+public class UserResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oauth2/src/main/resources/application.properties
+++ b/security/keycloak-oauth2/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# this will be overridden by an env var when deployed to OpenShift,
+# see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
+quarkus.oauth2.introspection-url=http://localhost:8180/auth/realms/test-realm/protocol/openid-connect/token/introspect
+quarkus.oauth2.client-id=test-application-client
+quarkus.oauth2.client-secret=test-application-client-secret
+quarkus.oauth2.role-claim=roles
+
+quarkus.openshift.expose=true
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.ts.openshift.app.metadata.AppMetadata;
+import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.injection.TestResource;
+import io.quarkus.ts.openshift.common.injection.WithName;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
+
+    static String oauth2IntrospectionUrl;
+
+    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
+    @CustomizeApplicationDeployment
+    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
+            throws IOException {
+        oauth2IntrospectionUrl = url + "/auth/realms/test-realm/protocol/openid-connect/token/introspect";
+
+        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
+        objs.stream()
+                .filter(it -> it instanceof DeploymentConfig)
+                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
+                .map(DeploymentConfig.class::cast)
+                .forEach(dc -> {
+                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
+                        container.getEnv().add(
+                                new EnvVar("QUARKUS_OAUTH2_INTROSPECTION_URL", oauth2IntrospectionUrl, null));
+                    });
+                });
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
+    }
+
+    @TestResource
+    private URL applicationUrl;
+
+    @Override
+    protected String getAppUrl() {
+        return applicationUrl.toString();
+    }
+
+    @Override
+    protected String getOAuth2IntrospectionUrl() {
+        return oauth2IntrospectionUrl;
+    }
+}

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,98 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import org.apache.http.impl.client.HttpClients;
+import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
+
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class AbstractSecurityKeycloakOpenShiftTest {
+
+    protected abstract String getOAuth2IntrospectionUrl();
+
+    protected abstract String getAppUrl();
+
+    private AuthzClient authzClient;
+
+    @BeforeEach
+    public void setup() {
+        authzClient = AuthzClient.create(new Configuration(
+                StringUtils.substringBefore(getOAuth2IntrospectionUrl(), "/realms"),
+                "test-realm",
+                "test-application-client",
+                Collections.singletonMap("secret", "test-application-client-secret"),
+                HttpClients.createDefault()
+        ));
+    }
+
+    @Test
+    public void normalUser_userResource() {
+        given()
+        .when()
+                .auth().preemptive().oauth2(getToken("test-normal-user", "test-normal-user"))
+                .get("/user")
+        .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user test-normal-user"));
+    }
+
+    @Test
+    public void normalUser_adminResource() {
+        given()
+        .when()
+                .auth().preemptive().oauth2(getToken("test-normal-user", "test-normal-user"))
+                .get("/admin")
+        .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void adminUser_userResource() {
+        given()
+        .when()
+                .auth().preemptive().oauth2(getToken("test-admin-user", "test-admin-user"))
+                .get("/user")
+        .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user test-admin-user"));
+    }
+
+    @Test
+    public void adminUser_adminResource() {
+        given()
+        .when()
+                .auth().preemptive().oauth2(getToken("test-admin-user", "test-admin-user"))
+                .get("/admin")
+        .then()
+                .statusCode(200)
+                .body(equalTo("Hello, admin test-admin-user"));
+    }
+
+    @Test
+    public void noUser_userResource() {
+        given()
+        .when()
+                .get("/user")
+        .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void noUser_adminResource() {
+        given()
+        .when()
+                .get("/admin")
+        .then()
+                .statusCode(401);
+    }
+
+    private String getToken(String userName, String password) {
+        return authzClient.obtainAccessToken(userName, password).getToken();
+    }
+}

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfNotConfigured("ts.authenticated-registry")
+public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfConfigured("ts.authenticated-registry")
+public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.ts.openshift.common.resources.KeycloakQuarkusTestResource;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@QuarkusTest
+@QuarkusTestResource(KeycloakQuarkusTestResource.WithOAuth2Config.class)
+public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenShiftTest {
+
+    @ConfigProperty(name = "quarkus.oauth2.introspection-url")
+    String oauth2IntrospectionUrl;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer appPort;
+
+    @Override
+    protected String getAppUrl() {
+        return "http://localhost:" + appPort;
+    }
+
+    @Override
+    protected String getOAuth2IntrospectionUrl() {
+        return oauth2IntrospectionUrl;
+    }
+}

--- a/security/keycloak-oauth2/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oauth2/src/test/resources/keycloak-realm.json
@@ -1,0 +1,73 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "test-user-role"
+      },
+      {
+        "name": "test-admin-role"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-normal-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-normal-user"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role"
+      ]
+    },
+    {
+      "username": "test-admin-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-admin-user"
+        }
+      ],
+      "realmRoles": [
+        "test-admin-role",
+        "test-user-role"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret",
+      "protocolMappers": [
+        {
+          "id": "12c7ffdd-f1bc-4e98-a625-20002527e1f4",
+          "name": "add-roles-to-claim",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/security/keycloak-oauth2/src/test/resources/keycloak-realm.yaml
+++ b/security/keycloak-oauth2/src/test/resources/keycloak-realm.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+data:
+  test-realm.json: |
+    {
+      "realm": "test-realm",
+      "enabled": true,
+      "sslRequired": "none",
+      "roles": {
+        "realm": [
+          {
+            "name": "test-user-role"
+          },
+          {
+            "name": "test-admin-role"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "test-normal-user",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-normal-user"
+            }
+          ],
+          "realmRoles": [
+            "test-user-role"
+          ]
+        },
+        {
+          "username": "test-admin-user",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-admin-user"
+            }
+          ],
+          "realmRoles": [
+            "test-admin-role",
+            "test-user-role"
+          ]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "test-application-client",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "test-application-client-secret",
+          "protocolMappers": [
+            {
+              "id": "12c7ffdd-f1bc-4e98-a625-20002527e1f4",
+              "name": "add-roles-to-claim",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "multivalued": "true",
+                "userinfo.token.claim": "false",
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+                "claim.name": "roles",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        }
+      ]
+    }


### PR DESCRIPTION
This is the same example as in security Keycloak, but using the OAuth2 quarkus extensions instead of OIDC.