### PR TITLE
openjdk/openjdk-11-rhel7 -> ubi8/openjdk-11

### DIFF
--- a/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
@@ -171,15 +171,7 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
                 new Command("oc", "start-build", getAppMetadata(context).appName, "--from-file=" + binary.get(), "--follow")
                         .runAndWait();
             } else {
-                // when generating Kubernetes resources, Quarkus expects that all application files
-                // will reside in `/deployments/target`, but if we did just `oc start-build my-app --from-dir=target`,
-                // the files would end up in `/deployments`
-                // using `tar` works around that nicely, because the tarball created with this command will have
-                // a single root directory named `target`, which the S2I builder image will unpack to `/deployments`
-                new Command("tar", "czf", "app.tar.gz", "target").runAndWait();
-                new Command("oc", "start-build", getAppMetadata(context).appName, "--from-archive=app.tar.gz", "--follow")
-                        .runAndWait();
-                new Command("rm", "app.tar.gz").runAndWait();
+                new Command("oc", "start-build", getAppMetadata(context).appName, "--from-dir=target", "--follow").runAndWait();
             }
         }
 

--- a/config-secret/api-server/src/main/resources/application.properties
+++ b/config-secret/api-server/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.openshift.expose=true
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.secrets.enabled=true
 quarkus.kubernetes-config.secrets=app-config
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
 %test.quarkus.kubernetes-config.enabled=false

--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.openshift.expose=true
 quarkus.openshift.secret-volumes.app-config.secret-name=app-config
 quarkus.openshift.mounts.app-config.path=/deployments/config
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
 

--- a/configmap/api-server/src/main/resources/application.properties
+++ b/configmap/api-server/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.openshift.expose=true
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.config-maps=app-config
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
 %test.quarkus.kubernetes-config.enabled=false

--- a/configmap/file-system/src/main/resources/application.properties
+++ b/configmap/file-system/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.openshift.expose=true
 quarkus.openshift.config-map-volumes.app-config.config-map-name=app-config
 quarkus.openshift.mounts.app-config.path=/deployments/config
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
 

--- a/deployment-strategies/quarkus-serverless/src/main/resources/application.properties
+++ b/deployment-strategies/quarkus-serverless/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.application.name=deployment-strategy-quarkus-serverless
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 quarkus.kubernetes.deployment-target=knative
 

--- a/deployment-strategies/quarkus/src/main/resources/application.properties
+++ b/deployment-strategies/quarkus/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.application.name=deployment-strategy-quarkus
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @OpenShiftTest
 @ManualApplicationDeployment
 @CustomAppMetadata(appName = "quarkus-workshop-hero", httpRoot = "/", knownEndpoint = "/")
-@AdditionalResources("classpath:openjdk-11-rhel7.yaml")
+@AdditionalResources("classpath:openjdk-11.yaml")
 @AdditionalResources("classpath:heroes-database.yaml")
 @AdditionalResources("classpath:hero.yaml")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @OpenShiftTest
 @ManualApplicationDeployment
 @CustomAppMetadata(appName = "quarkus-workshop-villain", httpRoot = "/", knownEndpoint = "/")
-@AdditionalResources("classpath:openjdk-11-rhel7.yaml")
+@AdditionalResources("classpath:openjdk-11.yaml")
 @AdditionalResources("classpath:villains-database.yaml")
 @AdditionalResources("classpath:villain.yaml")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -31,7 +31,7 @@ items:
           value: -p -r lib/ *-runner.jar
         from:
           kind: ImageStreamTag
-          name: openjdk-11-rhel7:latest
+          name: openjdk-11:latest
     triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/openjdk-11.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/openjdk-11.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: openjdk-11-rhel7
+  name: openjdk-11
 spec:
   lookupPolicy:
     local: false
@@ -9,4 +9,4 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: registry.access.redhat.com/openjdk/openjdk-11-rhel7
+      name: registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -31,7 +31,7 @@ items:
               value: -p -r lib/ *-runner.jar
           from:
             kind: ImageStreamTag
-            name: openjdk-11-rhel7:latest
+            name: openjdk-11:latest
       triggers:
         - type: ConfigChange
         - type: ImageChange

--- a/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
+++ b/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
@@ -14,7 +14,7 @@ import static io.restassured.RestAssured.when;
 @OpenShiftTest
 @ManualApplicationDeployment
 @CustomAppMetadata(appName = "todo-demo-app", httpRoot = "/", knownEndpoint = "/")
-@AdditionalResources("classpath:openjdk-11-rhel7.yaml")
+@AdditionalResources("classpath:openjdk-11.yaml")
 @AdditionalResources("classpath:todo-demo-app.yaml")
 public class TodoDemoAppOpenShiftIT {
     @TestResource

--- a/external-applications/todo-demo-app/src/test/resources/openjdk-11.yaml
+++ b/external-applications/todo-demo-app/src/test/resources/openjdk-11.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: openjdk-11-rhel7
+  name: openjdk-11
 spec:
   lookupPolicy:
     local: false
@@ -9,4 +9,4 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: registry.access.redhat.com/openjdk/openjdk-11-rhel7
+      name: registry.access.redhat.com/ubi8/openjdk-11

--- a/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
+++ b/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
@@ -30,7 +30,7 @@ items:
           value: -p -r lib/ *-runner.jar
         from:
           kind: ImageStreamTag
-          name: openjdk-11-rhel7:latest
+          name: openjdk-11:latest
     triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -58,10 +58,6 @@
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-health</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.ts.openshift</groupId>
             <artifactId>app-metadata</artifactId>
         </dependency>

--- a/http/src/main/resources/application.properties
+++ b/http/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.http.root-path=/api
 
 quarkus.kubernetes.deployment-target=openshift
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.1
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 quarkus.http.http2=true
 quarkus.http.ssl-port=8443
 quarkus.http.test-ssl-port=8445

--- a/http/src/main/resources/foobar.yaml
+++ b/http/src/main/resources/foobar.yaml
@@ -8,4 +8,4 @@ quarkus:
   openshift:
     expose: true
   s2i:
-    base-jvm-image: registry.access.redhat.com/openjdk/openjdk-11-rhel7
+    base-jvm-image: registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -23,7 +23,7 @@ quarkus.openshift.secret-volumes.my-volume.secret-name=clientcerts
 # instructs quarkus to build and deploy to kubernetes/openshift, and to trust the Kubernetes API since we're using self-signed
 quarkus.openshift.expose=true
 quarkus.kubernetes-client.trust-certs=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # manual deployment of application
 quarkus.container-image.build=true

--- a/messaging/amqp-reactive/src/main/resources/application.properties
+++ b/messaging/amqp-reactive/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.amqp-host=localhost
 amqp-host=amq-broker-amqp

--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616
 

--- a/messaging/artemis/src/main/resources/application.properties
+++ b/messaging/artemis/src/main/resources/application.properties
@@ -3,6 +3,6 @@ quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616

--- a/messaging/qpid/src/main/resources/application.properties
+++ b/messaging/qpid/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # QPID
 %test.quarkus.qpid-jms.url=amqp://localhost:5672

--- a/microprofile/src/main/resources/application.properties
+++ b/microprofile/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.jaeger.sampler-param=1
 quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 %test.io.quarkus.ts.openshift.microprofile.HelloClient/mp-rest/url=http://localhost:8081/
 %test.quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.10.5.Final</version.quarkus>
+        <version.quarkus>1.11.0.Final</version.quarkus>
         <version.testcontainers>1.15.1</version.testcontainers>
     </properties>
 

--- a/scaling/src/main/resources/application.properties
+++ b/scaling/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 quarkus.application.name=test-scaling
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/basic/src/main/resources/application.properties
+++ b/security/basic/src/main/resources/application.properties
@@ -8,4 +8,4 @@ quarkus.security.users.embedded.roles.albert=admin,user
 quarkus.security.users.embedded.roles.isaac=user
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/jwt/src/main/resources/application.properties
+++ b/security/jwt/src/main/resources/application.properties
@@ -5,4 +5,4 @@ smallrye.jwt.expiration.grace=120
 quarkus.security.deny-unannotated-members=true
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -11,4 +11,4 @@ quarkus.keycloak.policy-enforcer.paths.health.path=/health/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-jwt/src/main/resources/application.properties
+++ b/security/keycloak-jwt/src/main/resources/application.properties
@@ -10,4 +10,4 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.roles.source=accesstoken
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-webapp/src/main/resources/application.properties
+++ b/security/keycloak-webapp/src/main/resources/application.properties
@@ -11,4 +11,4 @@ quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak/src/main/resources/application.properties
+++ b/security/keycloak/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.oidc.credentials.secret=test-application-client-secret
 quarkus.oidc.token.lifespan-grace=60
 
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/sql-db/mariadb/src/main/resources/application.properties
+++ b/sql-db/mariadb/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mariadb
 quarkus.openshift.env-vars.DB_DATABASE.value=database

--- a/sql-db/mssql/src/main/resources/application.properties
+++ b/sql-db/mssql/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mssql
 quarkus.openshift.env-vars.DB_DATABASE.value=database

--- a/sql-db/mysql/src/main/resources/application.properties
+++ b/sql-db/mysql/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mysql
 quarkus.openshift.env-vars.DB_DATABASE.value=database

--- a/sql-db/postgresql/src/main/resources/application.properties
+++ b/sql-db/postgresql/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.expose=true
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/openjdk/openjdk-11-rhel7
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=postgresql
 quarkus.openshift.env-vars.DB_DATABASE.value=database


### PR DESCRIPTION
- Change deployment folder from /deployments/target to /deployments

- Upgrade Quarkus version to 1.11.0.Final
- move on to ubi-openjdk-11