### PR TITLE
k8s/openshift secret volumes required a smallrye config env variable …

### DIFF
--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 quarkus.openshift.expose=true
 quarkus.openshift.secret-volumes.app-config.secret-name=app-config
 quarkus.openshift.mounts.app-config.path=/deployments/config
+
+# TODO: remove workaround for https://github.com/quarkusio/quarkus/issues/14525
+quarkus.openshift.env.vars.smallrye-config-locations=/deployments/config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!


### PR DESCRIPTION
k8s/openshift secret volumes required a smallrye config env variable location. 
[issue ref](https://github.com/quarkusio/quarkus/issues/14525)

