### PR TITLE
Security authZ patch.

### DIFF
--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -7,7 +7,8 @@ quarkus.oidc.credentials.secret=test-application-client-secret
 quarkus.oidc.token.lifespan-grace=60
 
 quarkus.keycloak.policy-enforcer.enable=true
-quarkus.keycloak.policy-enforcer.paths.health.path=/health/*
+# QUARKUS-720: workaround, move on from health.path=/health/* to health.path=/q/health/*
+quarkus.keycloak.policy-enforcer.paths.health.path=/q/health/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 
 quarkus.openshift.expose=true


### PR DESCRIPTION
`quarkus.keycloak.policy-enforcer.paths.health.path` must include "/q" path.

Quarkus Version 1.7:
quarkus.keycloak.policy-enforcer.paths.health.path=/health/*

Quarkus Version 1.11:
quarkus.keycloak.policy-enforcer.paths.health.path=/q/health/* 