### PR TITLE
Add quarkus-jackson dependency to common module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,6 +18,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
         </dependency>


### PR DESCRIPTION
Add quarkus-jackson dependency to common module

Handles
```
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.489 s <<< FAILURE! - in io.quarkus.ts.openshift.messaging.artemis.ArtemisTest
Error:  testLastPrice  Time elapsed: 0.009 s  <<< ERROR!
java.lang.RuntimeException: java.lang.NoClassDefFoundError: io/quarkus/jackson/runtime/JacksonBuildTimeConfig
Caused by: java.lang.NoClassDefFoundError: io/quarkus/jackson/runtime/JacksonBuildTimeConfig
Caused by: java.lang.ClassNotFoundException: io.quarkus.jackson.runtime.JacksonBuildTimeConfig
```
introduced by https://github.com/quarkusio/quarkus/commit/02166114f52bf3b30f70797449c9a89a393ad468 adjustment