### PR TITLE
Add module for micrometer/prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ Therefore, if you want to run the tests with a different Java S2I image, run `mv
 In addition to common prerequisites for Java projects (JDK, Maven) and OpenShift (`oc`), the following utilities must also be installed on the machine where the test suite is being executed:
 
 - `tar`
+- an OpenShift instance where is enabled the monitoring for user-defined projects (see [documentation](https://docs.openshift.com/container-platform/4.6/monitoring/enabling-monitoring-for-user-defined-projects.html))
+- the OpenShift user must have permission to create ServiceMonitor CRDs and access to the `openshift-user-workload-monitoring` namespace:
+
+For example, if the OpenShift user is called `qe`, then we should have this cluster role assigned to it:
+
+```
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: monitor-crd-edit
+rules:
+- apiGroups: ["monitoring.coreos.com", "apiextensions.k8s.io"]
+  resources: ["prometheusrules", "servicemonitors", "podmonitors", "customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+EOF
+```
+
+And also, the same user `qe` should have access to the `openshift-user-workload-monitoring` namespace (this namespace is automatically created by the Prometheus operator when enabling the monitoring of user-defined projects):
+
+```
+oc adm policy add-role-to-user edit qe -n openshift-user-workload-monitoring
+```
+
+These requirements are necessary to verify the `micrometer/prometheus` tests. 
 
 ## Running against Red Hat build of Quarkus
 
@@ -519,6 +543,16 @@ It is possible to enable/disable the "hello" endpoint, which controls whether Fa
 All HTTP endpoints and internal processing is asynchronous, so Context Propagation is also required.
 JAX-RS endpoints and RestClient calls are automatically traced with OpenTracing, and some additional logging into the OpenTracing spans is also done.
 Jaeger is deployed in an "all-in-one" configuration, and the OpenShift test verifies the stored traces.
+
+### `micrometer/prometheus`
+
+Verifies that custom metrics are exposed in the embedded Prometheus instance provided by OpenShift.
+
+There is a PrimeNumberResource that checks whether an integer is prime or not. The application will expose the following custom metrics:
+- `prime_number_max_{uniqueId}`: max prime number that was found
+- `prime_number_test_{uniqueId}`: with information about the calculation of the prime number (count, max, sum)
+
+Where `{uniqueId}` is an unique identifier that is calculated at startup time to uniquely identify the metrics of the application.
 
 ### `messaging/artemis`
 

--- a/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
@@ -38,6 +38,11 @@ public class Command {
         return this;
     }
 
+    public Command outputToLines(List<String> lines) {
+        outputConsumer = linesOutput(lines);
+        return this;
+    }
+
     private static String descriptionOfProgram(String program) {
         if (program.contains(File.separator)) {
             return program.substring(program.lastIndexOf(File.separator) + 1);
@@ -82,6 +87,18 @@ public class Command {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     System.out.println(ansi().fgCyan().a(description).reset().a("> ").a(line));
+                }
+            } catch (IOException ignored) {
+            }
+        };
+    }
+
+    private static final BiConsumer<String, InputStream> linesOutput(List<String> lines) {
+        return (description, is) -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    lines.add(line);
                 }
             } catch (IOException ignored) {
             }

--- a/micrometer/prometheus/pom.xml
+++ b/micrometer/prometheus/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>micrometer-prometheus</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Micrometer: Prometheus</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>app-metadata</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/micrometer/prometheus/src/main/docker/Dockerfile.jvm
+++ b/micrometer/prometheus/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,34 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/http-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/http-jvm
+#
+###
+FROM fabric8/java-alpine-openjdk8-jre:1.6.5
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
+
+# Be prepared for running in OpenShift too
+RUN adduser -G root --no-create-home --disabled-password 1001 \
+  && chown -R 1001 /deployments \
+  && chmod -R "g+rwX" /deployments \
+  && chown -R 1001:root /deployments
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+EXPOSE 8080
+
+# run with user 1001
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/micrometer/prometheus/src/main/docker/Dockerfile.native
+++ b/micrometer/prometheus/src/main/docker/Dockerfile.native
@@ -1,0 +1,22 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the docker image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/http .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/http
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /work/
+COPY target/*-runner /work/application
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/micrometer/prometheus/src/main/java/io/quarkus/ts/openshift/micrometer/PrimeNumberResource.java
+++ b/micrometer/prometheus/src/main/java/io/quarkus/ts/openshift/micrometer/PrimeNumberResource.java
@@ -1,0 +1,76 @@
+package io.quarkus.ts.openshift.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.function.Supplier;
+
+@Path("/")
+public class PrimeNumberResource {
+
+    private final LongAccumulator highestPrime = new LongAccumulator(Long::max, 0);
+    private final MeterRegistry registry;
+    private final String uniqueId = RandomStringUtils.randomAlphabetic(5);
+
+    PrimeNumberResource(MeterRegistry registry) {
+        this.registry = registry;
+
+        // Create a gauge that uses the highestPrimeNumberSoFar method
+        // to obtain the highest observed prime number
+        registry.gauge("prime.number.max." + uniqueId, this,
+                PrimeNumberResource::highestObservedPrimeNumber);
+    }
+
+    @GET
+    @Path("/uniqueId")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
+    @GET
+    @Path("/check/{number}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String checkIfPrime(@PathParam("number") long number) {
+        if (number < 1) {
+            return "Only natural numbers can be prime numbers.";
+        }
+        if (number == 1) {
+            return "1 is not prime.";
+        }
+        if (number == 2) {
+            return "2 is prime.";
+        }
+        if (number % 2 == 0) {
+            return number + " is not prime, it is divisible by 2.";
+        }
+
+        Supplier<String> supplier = () -> {
+            for (int i = 3; i < Math.floor(Math.sqrt(number)) + 1; i = i + 2) {
+                if (number % i == 0) {
+                    return number + " is not prime, is divisible by " + i + ".";
+                }
+            }
+            highestPrime.accumulate(number);
+            return number + " is prime.";
+        };
+
+        return registry.timer("prime.number.test." + uniqueId).wrap(supplier).get();
+    }
+
+    /**
+     * This method is called by the registered {@code prime.number.max} gauge.
+     *
+     * @return the highest observed prime value
+     */
+    long highestObservedPrimeNumber() {
+        return highestPrime.get();
+    }
+}

--- a/micrometer/prometheus/src/main/resources/application.properties
+++ b/micrometer/prometheus/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.openshift.labels.app-with-metrics=quarkus-app
+quarkus.openshift.expose=true
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11

--- a/micrometer/prometheus/src/test/java/io/quarkus/ts/openshift/micrometer/PrimeNumberResourceOpenShiftIT.java
+++ b/micrometer/prometheus/src/test/java/io/quarkus/ts/openshift/micrometer/PrimeNumberResourceOpenShiftIT.java
@@ -1,0 +1,101 @@
+package io.quarkus.ts.openshift.micrometer;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.Command;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.deploy.UsingQuarkusPluginDeploymentStrategy;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.get;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The application contains a `PrimeNumberResource` resource that generates a few metrics:
+ * - `prime_number_max_{uniqueId}`: max prime number that is found
+ * - `prime_number_test_{uniqueId}`: with information about the calculation of the prime number
+ */
+@OpenShiftTest(strategy = UsingQuarkusPluginDeploymentStrategy.class)
+@AdditionalResources("classpath:service-monitor.yaml")
+public class PrimeNumberResourceOpenShiftIT {
+
+    private static final String PRIME_NUMBER_MAX = "prime_number_max_%s";
+
+    private static final String PRIME_NUMBER_TEST_COUNT = "prime_number_test_%s_seconds_count";
+    private static final String PRIME_NUMBER_TEST_MAX = "prime_number_test_%s_seconds_max";
+    private static final String PRIME_NUMBER_TEST_SUM = "prime_number_test_%s_seconds_sum";
+
+    private static final Integer ANY_VALUE = null;
+
+    private String uniqueId;
+
+    @BeforeEach
+    public void setup() {
+        uniqueId = get("/uniqueId").then().statusCode(HttpStatus.SC_OK).extract().asString();
+    }
+
+    @Test
+    public void primeNumberCustomMetricsShouldBeExposed() throws Exception {
+        whenCheckPrimeNumber(3); // It's prime, so it should set the prime.number.max metric.
+        whenCheckPrimeNumber(4); // It's not prime, so It's ignored.
+
+        thenMetricIsExposedInServiceEndpoint(PRIME_NUMBER_MAX, 3);
+        thenMetricIsExposedInServiceEndpoint(PRIME_NUMBER_TEST_COUNT, 1);
+        thenMetricIsExposedInServiceEndpoint(PRIME_NUMBER_TEST_MAX, ANY_VALUE);
+        thenMetricIsExposedInServiceEndpoint(PRIME_NUMBER_TEST_SUM, ANY_VALUE);
+
+        thenMetricIsExposedInPrometheus(PRIME_NUMBER_MAX, 3);
+        thenMetricIsExposedInPrometheus(PRIME_NUMBER_TEST_COUNT, 1);
+        thenMetricIsExposedInPrometheus(PRIME_NUMBER_TEST_MAX, ANY_VALUE);
+        thenMetricIsExposedInPrometheus(PRIME_NUMBER_TEST_SUM, ANY_VALUE);
+    }
+
+    private void whenCheckPrimeNumber(int number) {
+        get("/check/" + number).then().statusCode(HttpStatus.SC_OK);
+    }
+
+    private void thenMetricIsExposedInPrometheus(String name, Integer expected) throws Exception {
+        await().ignoreExceptions().atMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
+            List<String> lines = new LinkedList<>();
+            new Command("oc", "exec", "-n", "openshift-user-workload-monitoring",
+                    "pod/prometheus-user-workload-0", "curl",
+                    "http://localhost:9090/api/v1/query?query=" + primeNumberCustomMetricName(name))
+                            .outputToLines(lines)
+                            .runAndWait();
+            assertTrue(lines.stream().anyMatch(line -> line.contains("\"status\":\"success\"")), "Verify the status was ok");
+            assertTrue(
+                    lines.stream()
+                            .anyMatch(line -> line.contains("\"__name__\":\"" + primeNumberCustomMetricName(name) + "\"")),
+                    "Verify the metrics is found");
+            if (expected != null) {
+                assertTrue(lines.stream().anyMatch(line -> line.contains("\"" + expected + "\"")),
+                        "Verify the metrics contains the correct number");
+            }
+
+        });
+    }
+
+    private void thenMetricIsExposedInServiceEndpoint(String name, Integer expected) {
+        await().ignoreExceptions().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
+            String shouldContain = primeNumberCustomMetricName(name);
+            if (expected != null) {
+                shouldContain += " " + expected;
+            }
+
+            get("/q/metrics").then()
+                    .statusCode(200)
+                    .body(containsString(shouldContain));
+        });
+    }
+
+    private String primeNumberCustomMetricName(String metricName) {
+        return String.format(metricName, uniqueId);
+    }
+}

--- a/micrometer/prometheus/src/test/resources/service-monitor.yaml
+++ b/micrometer/prometheus/src/test/resources/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus-app-monitor
+  name: prometheus-app-monitor
+spec:
+  endpoints:
+  - interval: 30s
+    targetPort: 8080
+    scheme: http
+  selector:
+    matchLabels:
+      # Configured in application.properties: quarkus.openshift.labels.app-with-metrics
+      app-with-metrics: 'quarkus-app'

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>security/https-2way</module>
         <module>security/https-2way-authz</module>
         <module>microprofile</module>
+        <module>micrometer/prometheus</module>
 
         <module>external-applications/todo-demo-app</module>
         <module>external-applications/quarkus-workshop-super-heroes</module>


### PR DESCRIPTION
Verifies that custom metrics are exposed in the embedded Prometheus instance provided by OpenShift.

There is a PrimeNumberResource that checks whether an integer is prime or not. The application will expose the following custom metrics:
- `prime_number_max_{uniqueId}`: max prime number that was found
- `prime_number_test_{uniqueId}`: with information about the calculation of the prime number (count, max, sum)

Where `{uniqueId}` is an unique identifier that is calculated at startup time to uniquely identify the metrics of the application.