### PR TITLE
Configure env vars from additional deployments. Fixes #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,42 @@ public class HelloOpenShiftIT {
 These resources are deployed _before_ the test application is deployed, and are also undeployed _after_ the test application is undeployed.
 This annotation is `@Repeatable`, so you can include it more than once.
 
+Also, additional resources with routes sometimes need to be injected into the Quarkus applications. For example, if we have the next `route.yaml` file with content: 
+
+```yaml
+apiVersion: v1
+kind: List
+items:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: keycloak-plain
+  spec:
+    to:
+      name: keycloak-plain
+```
+
+Then, We can use the `@InjectRouteUrlIntoApp` annotation to inject the route URL into the Quarkus application as an environment variable:
+
+```java
+@OpenShiftTest
+@AdditionalResources("classpath:route.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
+public class HelloOpenShiftIT {
+    ...
+}
+```
+
+After deploying the route, the framework will deploy the module test application with the environment variable `KEYCLOAK_HTTP_URL` and the route URL.
+
+Note that environment variables are available to be used in properties files like:
+
+```properties
+quarkus.my.property=${KEYCLOAK_HTTP_URL:default_value}
+```
+
+Further information about usage of configuration in [here](https://quarkus.io/guides/config-reference#combine-property-env-var).
+
 ### Running tests in ephemeral namespaces
 
 By default, the test framework expects that the user is logged into an OpenShift project, and that project is used for all tests.

--- a/common/src/main/java/io/quarkus/ts/openshift/common/InjectRouteUrlIntoApp.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/InjectRouteUrlIntoApp.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.openshift.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Resolves the route endpoint and copies the value into the specified environment variable.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(InjectRouteUrlIntoAppContainer.class)
+public @interface InjectRouteUrlIntoApp {
+    String route();
+
+    String envVar();
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/InjectRouteUrlIntoAppContainer.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/InjectRouteUrlIntoAppContainer.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.openshift.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectRouteUrlIntoAppContainer {
+    InjectRouteUrlIntoApp[] value();
+}

--- a/common/src/main/java/io/quarkus/ts/openshift/common/deploy/DeploymentStrategy.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/deploy/DeploymentStrategy.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.openshift.common.deploy;
 
+import java.util.Map;
+
 /**
  * Interface to deploy a Quarkus application into OpenShift.
  */
@@ -8,7 +10,7 @@ public interface DeploymentStrategy {
     /**
      * Deploy action
      */
-    void deploy() throws Exception;
+    void deploy(Map<String, String> envVars) throws Exception;
 
     /**
      * Undeploy action

--- a/common/src/main/java/io/quarkus/ts/openshift/common/deploy/EmbeddedDeploymentStrategy.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/deploy/EmbeddedDeploymentStrategy.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -14,6 +15,7 @@ import io.quarkus.ts.openshift.common.Command;
 import io.quarkus.ts.openshift.common.OpenShiftTestException;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.util.AwaitUtil;
+import io.quarkus.ts.openshift.common.util.EnvVarsOverrides;
 import io.quarkus.ts.openshift.common.util.ImageOverrides;
 import io.quarkus.ts.openshift.common.util.NamespaceOverrides;
 
@@ -35,7 +37,7 @@ public class EmbeddedDeploymentStrategy implements DeploymentStrategy {
     private AwaitUtil awaitUtil;
 
     @Override
-    public void deploy() throws Exception {
+    public void deploy(Map<String, String> envVars) throws Exception {
         Path openshiftResources = getResourcesYaml();
         if (!Files.exists(openshiftResources)) {
             throw new OpenShiftTestException(
@@ -44,6 +46,7 @@ public class EmbeddedDeploymentStrategy implements DeploymentStrategy {
 
         NamespaceOverrides.apply(openshiftResources, openShiftClient);
         ImageOverrides.apply(openshiftResources, openShiftClient);
+        EnvVarsOverrides.apply(envVars, openshiftResources, openShiftClient);
 
         System.out.println("deploying application");
         new Command("oc", "apply", "-f", openshiftResources.toString()).runAndWait();

--- a/common/src/main/java/io/quarkus/ts/openshift/common/deploy/ManualDeploymentStrategy.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/deploy/ManualDeploymentStrategy.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.openshift.common.deploy;
 
+import java.util.Map;
+
 /**
  * If the test class is using the {@code ManualDeploymentStrategy} strategy, the test framework will delegate the deployment
  * to the test case.
@@ -9,7 +11,7 @@ package io.quarkus.ts.openshift.common.deploy;
 public class ManualDeploymentStrategy implements DeploymentStrategy {
 
     @Override
-    public void deploy() throws Exception {
+    public void deploy(Map<String, String> envVars) throws Exception {
         // Do nothing
     }
 

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/EnvVarsOverrides.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/EnvVarsOverrides.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.openshift.common.util;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+public final class EnvVarsOverrides {
+    public static void apply(Map<String, String> envVars, Path yaml, OpenShiftClient oc) throws IOException {
+        List<HasMetadata> objs = oc.load(Files.newInputStream(yaml)).get();
+
+        for (HasMetadata obj : objs) {
+            if (obj instanceof DeploymentConfig) {
+                DeploymentConfig dc = (DeploymentConfig) obj;
+
+                dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
+                    envVars.entrySet()
+                            .forEach(envVar -> container.getEnv().add(new EnvVar(envVar.getKey(), envVar.getValue(), null)));
+                });
+            }
+        }
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        Serialization.yamlMapper().writeValue(Files.newOutputStream(yaml), list);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Final-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
+                <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>
         </profile>
 

--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakAuthzOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/AbstractSecurityKeycloakAuthzOpenShiftIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/AbstractSecurityKeycloakAuthzOpenShiftIT.java
@@ -1,50 +1,18 @@
 package io.quarkus.ts.openshift.security.keycloak.authz;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakAuthzOpenShiftIT extends AbstractSecurityKeycloakAuthzOpenShiftTest {
 
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url) throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null)
-                        );
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
 
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 }

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak73AuthzOpenShiftIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak73AuthzOpenShiftIT.java
@@ -1,12 +1,14 @@
 package io.quarkus.ts.openshift.security.keycloak.authz;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
 @OpenShiftTest
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 // Run this test always as for RH SSO 7.4 is not working. Related issue: https://github.com/quarkusio/quarkus/issues/14318
 // @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73AuthzOpenShiftIT extends AbstractSecurityKeycloakAuthzOpenShiftIT {

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak74AuthzOpenShiftIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak74AuthzOpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak.authz;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 import org.junit.jupiter.api.Disabled;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Disabled;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74AuthzOpenShiftIT extends AbstractSecurityKeycloakAuthzOpenShiftIT {
 }

--- a/security/keycloak-jwt/src/main/resources/application.properties
+++ b/security/keycloak-jwt/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
-quarkus.oidc.token.issuer=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.token.issuer=${quarkus.oidc.auth-server-url}
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
 quarkus.oidc.application-type=web-app

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,58 +1,22 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
-
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null));
-
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_TOKEN_ISSUER", keycloakUrl, null));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
 
     @TestResource
     private URL applicationUrl;
 
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
+
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 
     @Override

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-multitenant/src/main/resources/application.properties
+++ b/security/keycloak-multitenant/src/main/resources/application.properties
@@ -1,27 +1,27 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-unused-client
 
 # Tenant For Webapp
-quarkus.oidc.webapp-tenant.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.webapp-tenant.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.webapp-tenant.client-id=test-webapp-client
 quarkus.oidc.webapp-tenant.credentials.secret=test-webapp-client-secret
 quarkus.oidc.webapp-tenant.application-type=web-app
 quarkus.oidc.webapp-tenant.roles.source=accesstoken
 
 # Tenant for Service
-quarkus.oidc.service-tenant.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.service-tenant.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.service-tenant.client-id=test-service-client
 quarkus.oidc.service-tenant.credentials.secret=test-service-client-secret
 quarkus.oidc.service-tenant.application-type=service
 
 # Tenant for JWT
-quarkus.oidc.jwt-tenant.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.jwt-tenant.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.jwt-tenant.client-id=test-jwt-client
 quarkus.oidc.jwt-tenant.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.jwt-tenant.application-type=web-app
-quarkus.oidc.jwt-tenant.token.issuer=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.jwt-tenant.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.jwt-tenant.roles.source=accesstoken
 
 quarkus.openshift.expose=true

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,64 +1,21 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Stream;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
-
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null));
-
-                        Stream.of(Tenant.values())
-                                .map(t -> String.format("QUARKUS_OIDC_%s_AUTH_SERVER_URL",
-                                        t.getValue().toUpperCase().replaceAll("-", "_")))
-                                .forEach(property -> container.getEnv().add(new EnvVar(property, keycloakUrl, null)));
-
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_JWT_TENANT_TOKEN_ISSUER", keycloakUrl, null));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
 
     @TestResource
     private URL applicationUrl;
 
+    @TestResource @WithName("keycloak-plain")
+    private URL keycloakUrl;
+
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 
     @Override

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -54,10 +54,11 @@ public abstract class AbstractSecurityKeycloakOpenShiftTest {
         String loc = webClient.loadWebResponse(new WebRequest(URI.create(getEndpointByTenant(webAppTenant)).toURL()))
                 .getResponseHeaderValue("location");
 
-        assertTrue(loc.startsWith(getAuthServerUrl() + "/protocol/openid-connect/auth"));
-        assertTrue(loc.contains("scope=openid"));
-        assertTrue(loc.contains("response_type=code"));
-        assertTrue(loc.contains("client_id=" + webAppTenant.getClientId()));
+        assertTrue(loc.startsWith(getAuthServerUrl()), "Unexpected location for " + getAuthServerUrl() + ". Got: " + loc);
+        assertTrue(loc.contains("scope=openid"), "Unexpected scope. Got: " + loc);
+        assertTrue(loc.contains("response_type=code"), "Unexpected response type. Got: " + loc);
+        assertTrue(loc.contains("client_id=" + webAppTenant.getClientId()),
+                "Unexpected client id for " + webAppTenant.getClientId() + " . Got: " + loc);
     }
 
     @ParameterizedTest

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -5,16 +5,9 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.ts.openshift.common.resources.KeycloakQuarkusTestResource;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
-
 @QuarkusTest
-@QuarkusTestResource(SecurityKeycloakOpenShiftTest.CustomKeycloakQuarkusTestResource.class)
+@QuarkusTestResource(KeycloakQuarkusTestResource.WithOidcConfig.class)
 public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenShiftTest {
-
-    private static final String OIDC_TENANT_AUTH_URL_PROPERTY = "quarkus.oidc.%s.auth-server-url";
-    private static final String OIDC_JWT_TENANT_AUTH_TOKEN_ISSUER = "quarkus.oidc.jwt-tenant.token.issuer";
 
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     String oidcAuthServerUrl;
@@ -30,17 +23,5 @@ public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenS
     @Override
     protected String getAuthServerUrl() {
         return oidcAuthServerUrl;
-    }
-
-    public static class CustomKeycloakQuarkusTestResource extends KeycloakQuarkusTestResource.WithOidcConfig {
-        @Override
-        protected Map<String, String> providesQuarkusConfiguration() {
-            Map<String, String> properties = new HashMap<>(super.providesQuarkusConfiguration());
-            Stream.of(Tenant.values())
-                    .forEach(t -> properties.put(String.format(OIDC_TENANT_AUTH_URL_PROPERTY, t.getValue()), realmAuthUrl()));
-
-            properties.put(OIDC_JWT_TENANT_AUTH_TOKEN_ISSUER, realmAuthUrl());
-            return properties;
-        }
     }
 }

--- a/security/keycloak-oauth2/src/main/resources/application.properties
+++ b/security/keycloak-oauth2/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oauth2.introspection-url=http://localhost:8180/auth/realms/test-realm/protocol/openid-connect/token/introspect
+quarkus.oauth2.introspection-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm/protocol/openid-connect/token/introspect
 quarkus.oauth2.client-id=test-application-client
 quarkus.oauth2.client-secret=test-application-client-secret
 quarkus.oauth2.role-claim=roles

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,59 +1,26 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
-
-    static String oauth2IntrospectionUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        oauth2IntrospectionUrl = url + "/auth/realms/test-realm/protocol/openid-connect/token/introspect";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OAUTH2_INTROSPECTION_URL", oauth2IntrospectionUrl, null));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
 
     @TestResource
     private URL applicationUrl;
 
-    @Override
-    protected String getAppUrl() {
-        return applicationUrl.toString();
-    }
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
 
     @Override
     protected String getOAuth2IntrospectionUrl() {
-        return oauth2IntrospectionUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm/protocol/openid-connect/token/introspect";
+    }
+
+    @Override
+    protected String getAppUrl() {
+        return applicationUrl.toString();
     }
 }

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-oidc-client/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client/src/main/resources/application.properties
@@ -1,18 +1,18 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see AbstractSecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
 
 # OIDC Client Configuration
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=test-application-client
 quarkus.oidc-client.credentials.secret=test-application-client-secret
 
 ## Normal User Password
-quarkus.oidc-client.normal-user.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.normal-user.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.normal-user.client-id=test-application-client
 quarkus.oidc-client.normal-user.credentials.secret=test-application-client-secret
 quarkus.oidc-client.normal-user.grant.type=password
@@ -20,7 +20,7 @@ quarkus.oidc-client.normal-user.grant-options.password.username=test-normal-user
 quarkus.oidc-client.normal-user.grant-options.password.password=test-normal-user
 
 ## Admin User Password
-quarkus.oidc-client.admin-user.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.admin-user.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.admin-user.client-id=test-application-client
 quarkus.oidc-client.admin-user.credentials.secret=test-application-client-secret
 quarkus.oidc-client.admin-user.grant.type=password
@@ -28,7 +28,7 @@ quarkus.oidc-client.admin-user.grant-options.password.username=test-admin-user
 quarkus.oidc-client.admin-user.grant-options.password.password=test-admin-user
 
 ## JWT
-quarkus.oidc-client.jwt-secret.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.jwt-secret.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt-secret.client-id=test-application-client-jwt
 quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,57 +1,18 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
 
-    private static final List<String> PROPERTIES_TO_SET_AUTH_URL = Arrays.asList("QUARKUS_OIDC_AUTH_SERVER_URL",
-            "QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL",
-            "QUARKUS_OIDC_CLIENT_NORMAL_USER_AUTH_SERVER_URL",
-            "QUARKUS_OIDC_CLIENT_ADMIN_USER_AUTH_SERVER_URL",
-            "QUARKUS_OIDC_CLIENT_JWT_SECRET_AUTH_SERVER_URL");
-
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        PROPERTIES_TO_SET_AUTH_URL.forEach(property -> container.getEnv().add(
-                                new EnvVar(property, keycloakUrl, null)));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
 
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 }

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -5,19 +5,9 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.ts.openshift.common.resources.KeycloakQuarkusTestResource;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 @QuarkusTest
-@QuarkusTestResource(SecurityKeycloakOpenShiftTest.CustomKeycloakQuarkusTestResource.class)
+@QuarkusTestResource(KeycloakQuarkusTestResource.WithOidcConfig.class)
 public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenShiftTest {
-
-    private static final List<String> PROPERTIES_TO_SET_AUTH_URL = Arrays.asList("quarkus.oidc-client.auth-server-url",
-            "quarkus.oidc-client.normal-user.auth-server-url",
-            "quarkus.oidc-client.admin-user.auth-server-url",
-            "quarkus.oidc-client.jwt-secret.auth-server-url");
 
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     String oidcAuthServerUrl;
@@ -25,14 +15,5 @@ public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenS
     @Override
     protected String getAuthServerUrl() {
         return oidcAuthServerUrl;
-    }
-
-    public static class CustomKeycloakQuarkusTestResource extends KeycloakQuarkusTestResource.WithOidcConfig {
-        @Override
-        protected Map<String, String> providesQuarkusConfiguration() {
-            Map<String, String> properties = new HashMap<>(super.providesQuarkusConfiguration());
-            PROPERTIES_TO_SET_AUTH_URL.forEach(property -> properties.put(property, realmAuthUrl()));
-            return properties;
-        }
     }
 }

--- a/security/keycloak-webapp/src/main/resources/application.properties
+++ b/security/keycloak-webapp/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 5 seconds of clock skew between the Keycloak server and the application

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,55 +1,22 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
-
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
 
     @TestResource
     private URL applicationUrl;
 
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
+
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 
     @Override

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -51,10 +51,10 @@ public abstract class AbstractSecurityKeycloakOpenShiftTest {
         String loc = webClient.loadWebResponse(new WebRequest(URI.create(getAppUrl() + "/user").toURL()))
                 .getResponseHeaderValue("location");
 
-        assertTrue(loc.startsWith(getAuthServerUrl() + "/protocol/openid-connect/auth"));
-        assertTrue(loc.contains("scope=openid"));
-        assertTrue(loc.contains("response_type=code"));
-        assertTrue(loc.contains("client_id=test-application-client"));
+        assertTrue(loc.startsWith(getAuthServerUrl()), "Unexpected location for " + getAuthServerUrl() + ". Got: " + loc);
+        assertTrue(loc.contains("scope=openid"), "Unexpected scope. Got: " + loc);
+        assertTrue(loc.contains("response_type=code"), "Unexpected response type. Got: " + loc);
+        assertTrue(loc.contains("client_id=test-application-client"), "Unexpected client id. Got: " + loc);
     }
 
     @Test

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak/src/main/resources/application.properties
+++ b/security/keycloak/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # this will be overridden by an env var when deployed to OpenShift,
 # see SecurityKeycloakOpenShiftIT.configureKeycloakUrl
-quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 5 seconds of clock skew between the Keycloak server and the application

--- a/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,55 +1,22 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.quarkus.ts.openshift.app.metadata.AppMetadata;
-import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import io.quarkus.ts.openshift.common.injection.WithName;
 
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
 
 public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
-
-    static String keycloakUrl;
-
-    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
-    @CustomizeApplicationDeployment
-    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
-            throws IOException {
-        keycloakUrl = url + "/auth/realms/test-realm";
-
-        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
-        objs.stream()
-                .filter(it -> it instanceof DeploymentConfig)
-                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
-                .map(DeploymentConfig.class::cast)
-                .forEach(dc -> {
-                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
-                        container.getEnv().add(
-                                new EnvVar("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakUrl, null));
-                    });
-                });
-
-        KubernetesList list = new KubernetesList();
-        list.setItems(objs);
-        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
-    }
 
     @TestResource
     private URL applicationUrl;
 
+    @TestResource
+    @WithName("keycloak-plain")
+    private URL keycloakUrl;
+
     @Override
     protected String getAuthServerUrl() {
-        return keycloakUrl;
+        return keycloakUrl.toString() + "/auth/realms/test-realm";
     }
 
     @Override

--- a/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.openshift.security.keycloak;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
@@ -8,6 +9,7 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
 @OnlyIfConfigured("ts.authenticated-registry")
 public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.openshift.security.keycloak;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.ts.openshift.common.resources.KeycloakQuarkusTestResource;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @QuarkusTest


### PR DESCRIPTION
Additional resources with routes sometimes need to be injected into the Quarkus applications. For example, if we have the next `route.yaml` file with content: 

```yaml
apiVersion: v1
kind: List
items:
- apiVersion: route.openshift.io/v1
  kind: Route
  metadata:
    name: keycloak-plain
  spec:
    to:
      name: keycloak-plain
```

Then, We can use the `@InjectRouteUrlIntoApp` annotation to inject the route URL into the Quarkus application as an environment variable:

```java
@OpenShiftTest
@AdditionalResources("classpath:route.yaml")
@InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
public class HelloOpenShiftIT {
    ...
}
```

After deploying the route, the framework will deploy the module test application with the environment variable `KEYCLOAK_HTTP_URL` and the route URL.