### PR TITLE
Added scenarios with OIDC Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,14 @@ Authorization is based on roles, which are configured in Keycloak.
 
 A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.
 
+### `security/keycloak-oidc-client`
+
+Verifies authorization using `OIDC Client` extension as token generator. 
+Keycloak is used for issuing and verifying tokens.
+Restrictions are defined using common annotations (`@RolesAllowed` etc.).
+
+A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.
+
 ### `security/https-1way`
 
 Verifies that accessing an HTTPS endpoint is posible.

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <module>security/keycloak-jwt</module>
         <module>security/keycloak-oauth2</module>
         <module>security/keycloak-multitenant</module>
+        <module>security/keycloak-oidc-client</module>
         <module>security/https-1way</module>
         <module>security/https-2way</module>
         <module>security/https-2way-authz</module>

--- a/security/keycloak-oidc-client/pom.xml
+++ b/security/keycloak-oidc-client/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>security-keycloak-oidc-client</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Security: Keycloak + OIDC Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client-filter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>app-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
+++ b/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/AdminResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/admin")
+@RolesAllowed("test-admin-role")
+public class AdminResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, admin " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/SecuredResource.java
+++ b/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/SecuredResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/secured")
+public class SecuredResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @RolesAllowed("**")
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/TokenProviderResource.java
+++ b/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/TokenProviderResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/generate-token")
+public class TokenProviderResource {
+    @Inject
+    OidcClient defaultOidcClient;
+
+    @Inject
+    OidcClients allOidcClients;
+
+    @GET
+    @Path("/client-credentials")
+    public String getTokenUsingClientCredentialsGrant() {
+        // By default, it's configured using client credentials
+        return generateToken(defaultOidcClient);
+    }
+
+    @GET
+    @Path("/jwt-secret")
+    public String getTokenUsingJwtSecret() {
+        return generateToken(allOidcClients.getClient("jwt-secret"));
+    }
+
+    @GET
+    @Path("/normal-user-password")
+    public String getTokenUsingNormalUserPasswordGrant() {
+        return generateToken(allOidcClients.getClient("normal-user"));
+    }
+
+    @GET
+    @Path("/admin-user-password")
+    public String getTokenUsingAdminUserPasswordGrant() {
+        return generateToken(allOidcClients.getClient("admin-user"));
+    }
+
+    private String generateToken(OidcClient client) {
+        return client.getTokens().await().indefinitely().getAccessToken();
+    }
+}

--- a/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
+++ b/security/keycloak-oidc-client/src/main/java/io/quarkus/ts/openshift/security/keycloak/UserResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/user")
+@RolesAllowed("test-user-role")
+public class UserResource {
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    JsonWebToken jwt;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+
+    @GET
+    @Path("/issuer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String issuer() {
+        return "user token issued by " + jwt.getIssuer();
+    }
+}

--- a/security/keycloak-oidc-client/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client/src/main/resources/application.properties
@@ -1,0 +1,36 @@
+# this will be overridden by an env var when deployed to OpenShift,
+# see AbstractSecurityKeycloakOpenShiftIT.configureKeycloakUrl
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc.client-id=test-application-client
+quarkus.oidc.credentials.secret=test-application-client-secret
+# tolerate 1 minute of clock skew between the Keycloak server and the application
+quarkus.oidc.token.lifespan-grace=60
+
+# OIDC Client Configuration
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.client-id=test-application-client
+quarkus.oidc-client.credentials.secret=test-application-client-secret
+
+## Normal User Password
+quarkus.oidc-client.normal-user.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.normal-user.client-id=test-application-client
+quarkus.oidc-client.normal-user.credentials.secret=test-application-client-secret
+quarkus.oidc-client.normal-user.grant.type=password
+quarkus.oidc-client.normal-user.grant-options.password.username=test-normal-user
+quarkus.oidc-client.normal-user.grant-options.password.password=test-normal-user
+
+## Admin User Password
+quarkus.oidc-client.admin-user.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.admin-user.client-id=test-application-client
+quarkus.oidc-client.admin-user.credentials.secret=test-application-client-secret
+quarkus.oidc-client.admin-user.grant.type=password
+quarkus.oidc-client.admin-user.grant-options.password.username=test-admin-user
+quarkus.oidc-client.admin-user.grant-options.password.password=test-admin-user
+
+## JWT
+quarkus.oidc-client.jwt-secret.auth-server-url=http://localhost:8180/auth/realms/test-realm
+quarkus.oidc-client.jwt-secret.client-id=test-application-client-jwt
+quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
+quarkus.openshift.expose=true
+quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftIT.java
@@ -1,0 +1,57 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.ts.openshift.app.metadata.AppMetadata;
+import io.quarkus.ts.openshift.common.CustomizeApplicationDeployment;
+import io.quarkus.ts.openshift.common.injection.WithName;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class AbstractSecurityKeycloakOpenShiftIT extends AbstractSecurityKeycloakOpenShiftTest {
+
+    private static final List<String> PROPERTIES_TO_SET_AUTH_URL = Arrays.asList("QUARKUS_OIDC_AUTH_SERVER_URL",
+            "QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL",
+            "QUARKUS_OIDC_CLIENT_NORMAL_USER_AUTH_SERVER_URL",
+            "QUARKUS_OIDC_CLIENT_ADMIN_USER_AUTH_SERVER_URL",
+            "QUARKUS_OIDC_CLIENT_JWT_SECRET_AUTH_SERVER_URL");
+
+    static String keycloakUrl;
+
+    // TODO this is pretty ugly, but I'm tired and can't think of a better way at the moment
+    @CustomizeApplicationDeployment
+    public static void configureKeycloakUrl(OpenShiftClient oc, AppMetadata appMetadata, @WithName("keycloak-plain") URL url)
+            throws IOException {
+        keycloakUrl = url + "/auth/realms/test-realm";
+
+        List<HasMetadata> objs = oc.load(Files.newInputStream(Paths.get("target/kubernetes/openshift.yml"))).get();
+        objs.stream()
+                .filter(it -> it instanceof DeploymentConfig)
+                .filter(it -> it.getMetadata().getName().equals(appMetadata.appName))
+                .map(DeploymentConfig.class::cast)
+                .forEach(dc -> {
+                    dc.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
+                        PROPERTIES_TO_SET_AUTH_URL.forEach(property -> container.getEnv().add(
+                                new EnvVar(property, keycloakUrl, null)));
+                    });
+                });
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        Serialization.yamlMapper().writeValue(Files.newOutputStream(Paths.get("target/kubernetes/openshift.yml")), list);
+    }
+
+    @Override
+    protected String getAuthServerUrl() {
+        return keycloakUrl;
+    }
+}

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,131 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class AbstractSecurityKeycloakOpenShiftTest {
+
+    protected abstract String getAuthServerUrl();
+
+    @Test
+    public void clientCredentials_securedResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.CLIENT_CREDENTIALS.getToken())
+                .get("/secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user service-account-test-application-client"));
+    }
+
+    @Test
+    public void jwtSecret_securedResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.JWT.getToken())
+                .get("/secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user service-account-test-application-client-jwt"));
+    }
+
+    @Test
+    public void normalUser_userResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.NORMAL_USER.getToken())
+                .get("/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user test-normal-user"));
+    }
+
+    @Test
+    public void normalUser_userResource_issuer() {
+        given()
+                .when()
+                .auth().oauth2(TokenProviderMethod.NORMAL_USER.getToken())
+                .get("/user/issuer")
+                .then()
+                .statusCode(200)
+                .body(equalTo("user token issued by " + getAuthServerUrl()));
+    }
+
+    @Test
+    public void normalUser_adminResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.NORMAL_USER.getToken())
+                .get("/admin")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void adminUser_userResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.ADMIN_USER.getToken())
+                .get("/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user test-admin-user"));
+    }
+
+    @Test
+    public void adminUser_adminResource() {
+        given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.ADMIN_USER.getToken())
+                .get("/admin")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, admin test-admin-user"));
+    }
+
+    @Test
+    public void noUser_securedResource() {
+        given()
+                .when()
+                .get("/secured")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void noUser_userResource() {
+        given()
+                .when()
+                .get("/user")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void noUser_adminResource() {
+        given()
+                .when()
+                .get("/admin")
+                .then()
+                .statusCode(401);
+    }
+
+    public enum TokenProviderMethod {
+        CLIENT_CREDENTIALS("client-credentials"),
+        JWT("jwt-secret"),
+        NORMAL_USER("normal-user-password"),
+        ADMIN_USER("admin-user-password");
+
+        private final String path;
+
+        TokenProviderMethod(String path) {
+            this.path = path;
+        }
+
+        public String getToken() {
+            return given().when().get("/generate-token/" + path).then().statusCode(200).extract().asString();
+        }
+    }
+}

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak73OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-73.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfNotConfigured("ts.authenticated-registry")
+public class SecurityKeycloak73OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloak74OpenShiftIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.OnlyIfConfigured;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+
+@OpenShiftTest
+@AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
+@AdditionalResources("classpath:keycloak-realm.yaml")
+@AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
+@OnlyIfConfigured("ts.authenticated-registry")
+public class SecurityKeycloak74OpenShiftIT extends AbstractSecurityKeycloakOpenShiftIT {
+}

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/openshift/security/keycloak/SecurityKeycloakOpenShiftTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.openshift.security.keycloak;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.ts.openshift.common.resources.KeycloakQuarkusTestResource;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@QuarkusTest
+@QuarkusTestResource(SecurityKeycloakOpenShiftTest.CustomKeycloakQuarkusTestResource.class)
+public class SecurityKeycloakOpenShiftTest extends AbstractSecurityKeycloakOpenShiftTest {
+
+    private static final List<String> PROPERTIES_TO_SET_AUTH_URL = Arrays.asList("quarkus.oidc-client.auth-server-url",
+            "quarkus.oidc-client.normal-user.auth-server-url",
+            "quarkus.oidc-client.admin-user.auth-server-url",
+            "quarkus.oidc-client.jwt-secret.auth-server-url");
+
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    String oidcAuthServerUrl;
+
+    @Override
+    protected String getAuthServerUrl() {
+        return oidcAuthServerUrl;
+    }
+
+    public static class CustomKeycloakQuarkusTestResource extends KeycloakQuarkusTestResource.WithOidcConfig {
+        @Override
+        protected Map<String, String> providesQuarkusConfiguration() {
+            Map<String, String> properties = new HashMap<>(super.providesQuarkusConfiguration());
+            PROPERTIES_TO_SET_AUTH_URL.forEach(property -> properties.put(property, realmAuthUrl()));
+            return properties;
+        }
+    }
+}

--- a/security/keycloak-oidc-client/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oidc-client/src/test/resources/keycloak-realm.json
@@ -1,0 +1,71 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "test-user-role"
+      },
+      {
+        "name": "test-admin-role"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-normal-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-normal-user"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role"
+      ]
+    },
+    {
+      "username": "test-admin-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-admin-user"
+        }
+      ],
+      "realmRoles": [
+        "test-admin-role",
+        "test-user-role"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret"
+    },
+    {
+      "clientId": "test-application-client-jwt",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret-jwt",
+      "secret": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+      "redirectUris": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/security/keycloak-oidc-client/src/test/resources/keycloak-realm.yaml
+++ b/security/keycloak-oidc-client/src/test/resources/keycloak-realm.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+data:
+  test-realm.json: |
+    {
+      "realm": "test-realm",
+      "enabled": true,
+      "sslRequired": "none",
+      "roles": {
+        "realm": [
+          {
+            "name": "test-user-role"
+          },
+          {
+            "name": "test-admin-role"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "test-normal-user",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-normal-user"
+            }
+          ],
+          "realmRoles": [
+            "test-user-role"
+          ]
+        },
+        {
+          "username": "test-admin-user",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "test-admin-user"
+            }
+          ],
+          "realmRoles": [
+            "test-admin-role",
+            "test-user-role"
+          ]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "test-application-client",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "test-application-client-secret"
+        },
+        {
+          "clientId": "test-application-client-jwt",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "clientAuthenticatorType": "client-secret-jwt",
+          "secret": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+          "redirectUris": [
+            "*"
+          ]
+        }
+      ]
+    }


### PR DESCRIPTION
Verifies authorization using `OIDC Client` extension as token generator. 
Keycloak is used for issuing and verifying tokens.
Restrictions are defined using common annotations (`@RolesAllowed` etc.).

A simple Keycloak realm with 1 client (protected application), 2 users and 2 roles is provided in `test-realm.json`.