### PR TITLE
Separate current quarkus version into platform and plugin versions

### DIFF
--- a/app-metadata/deployment/pom.xml
+++ b/app-metadata/deployment/pom.xml
@@ -16,18 +16,6 @@
 
     <name>Quarkus OpenShift TS: App Metadata: Deployment</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${version.quarkus}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus.ts.openshift</groupId>
@@ -58,7 +46,7 @@
                         <path>
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${version.quarkus}</version>
+                            <version>${version.plugin.quarkus}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/app-metadata/runtime/pom.xml
+++ b/app-metadata/runtime/pom.xml
@@ -28,7 +28,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${version.quarkus}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -48,7 +47,7 @@
                         <path>
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${version.quarkus}</version>
+                            <version>${version.plugin.quarkus}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
         <version.quarkus>1.11.1.Final</version.quarkus>
+        <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.1</version.testcontainers>
     </properties>
 
@@ -173,7 +174,7 @@
                 <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${version.quarkus}</version>
+                    <version>${version.plugin.quarkus}</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Separate current quarkus version into platform (`version.quarkus`) and plugin (`version.plugin.quarkus`) versions. If only platform quarkus version is provided, this version will be used for platform and plugin both. Therefore, we don't need to change anything as it was working previously.