### PR TITLE
[master] Upgrade Quarkus to 1.12.2.Final and some workarounds removed

### DIFF
--- a/common/src/main/java/io/quarkus/ts/openshift/common/deploy/EmbeddedDeploymentStrategy.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/deploy/EmbeddedDeploymentStrategy.java
@@ -58,7 +58,7 @@ public class EmbeddedDeploymentStrategy implements DeploymentStrategy {
             new Command("oc", "start-build", appMetadata.appName, "--from-file=" + binary.get(), "--follow")
                     .runAndWait();
         } else {
-            new Command("oc", "start-build", appMetadata.appName, "--from-dir=target", "--follow").runAndWait();
+            new Command("oc", "start-build", appMetadata.appName, "--from-dir=target/quarkus-app", "--follow").runAndWait();
         }
     }
 

--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 quarkus.openshift.expose=true
-quarkus.openshift.secret-volumes.app-config.secret-name=app-config
-quarkus.openshift.mounts.app-config.path=/deployments/config
+quarkus.openshift.app-secret=app-config
 
-# TODO: remove workaround for https://github.com/quarkusio/quarkus/issues/14525
-quarkus.openshift.env.vars.smallrye-config-locations=/deployments/config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!

--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -4,6 +4,3 @@ quarkus.openshift.app-secret=app-config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
-
-# the application binary resides in /home/quarkus with quarkus/ubi-quarkus-native-binary-s2i
-%native.quarkus.openshift.mounts.app-config.path=/home/quarkus/config

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -34,7 +34,7 @@ items:
         - name: ARTIFACT_COPY_ARGS
           value: -p -r lib/ *-runner.jar
         - name: MAVEN_ARGS
-          value: -s /configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
+          value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
           kind: ImageStreamTag
           name: openjdk-11:latest
@@ -60,8 +60,6 @@ items:
         - name: quarkus-workshop-hero
           image: quarkus-workshop-hero:latest
           env:
-          - name: ARTIFACT_COPY_ARGS
-            value: -p -r lib/ *-runner.jar
           - name: QUARKUS_DATASOURCE_JDBC_URL
             value: jdbc:postgresql://heroes-database:5432/heroes-database
           - name: QUARKUS_HTTP_PORT

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -32,7 +32,7 @@ items:
       sourceStrategy:
         env:
         - name: ARTIFACT_COPY_ARGS
-          value: -p -r lib/ *-runner.jar
+          value: -p -r *-runner.jar
         - name: MAVEN_ARGS
           value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -32,7 +32,7 @@ items:
         sourceStrategy:
           env:
             - name: ARTIFACT_COPY_ARGS
-              value: -p -r lib/ *-runner.jar
+              value: -p -r *-runner.jar
             - name: MAVEN_ARGS
               value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
           from:

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -34,7 +34,7 @@ items:
             - name: ARTIFACT_COPY_ARGS
               value: -p -r lib/ *-runner.jar
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
+              value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
           from:
             kind: ImageStreamTag
             name: openjdk-11:latest
@@ -60,8 +60,6 @@ items:
             - name: quarkus-workshop-villain
               image: quarkus-workshop-villain:latest
               env:
-                - name: ARTIFACT_COPY_ARGS
-                  value: -p -r lib/ *-runner.jar
                 - name: QUARKUS_DATASOURCE_JDBC_URL
                   value: jdbc:postgresql://villains-database:5432/villains-database
                 - name: QUARKUS_HTTP_PORT

--- a/external-applications/todo-demo-app/pom.xml
+++ b/external-applications/todo-demo-app/pom.xml
@@ -25,6 +25,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
+++ b/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
@@ -14,6 +14,7 @@ import static io.restassured.RestAssured.when;
 @OpenShiftTest(strategy = ManualDeploymentStrategy.class)
 @CustomAppMetadata(appName = "todo-demo-app", httpRoot = "/", knownEndpoint = "/")
 @AdditionalResources("classpath:openjdk-11.yaml")
+@AdditionalResources("classpath:deployments/maven/s2i-maven-settings.yaml")
 @AdditionalResources("classpath:todo-demo-app.yaml")
 public class TodoDemoAppOpenShiftIT {
     @TestResource

--- a/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
+++ b/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
@@ -22,12 +22,18 @@ items:
       git:
         uri: https://github.com/quarkusio/todo-demo-app.git
       type: Git
+      configMaps:
+      - configMap:
+          name: settings-mvn
+        destinationDir: "configuration"
     strategy:
       type: Source
       sourceStrategy:
         env:
         - name: ARTIFACT_COPY_ARGS
           value: -p -r lib/ *-runner.jar
+        - name: MAVEN_ARGS
+          value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
           kind: ImageStreamTag
           name: openjdk-11:latest
@@ -52,9 +58,6 @@ items:
         containers:
         - name: todo-demo-app
           image: todo-demo-app:latest
-          env:
-          - name: ARTIFACT_COPY_ARGS
-            value: -p -r lib/ *-runner.jar
           ports:
           - containerPort: 8080
             protocol: TCP

--- a/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
+++ b/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
@@ -25,15 +25,15 @@ items:
       configMaps:
       - configMap:
           name: settings-mvn
-        destinationDir: "configuration"
+        destinationDir: "/configuration"
     strategy:
       type: Source
       sourceStrategy:
         env:
         - name: ARTIFACT_COPY_ARGS
-          value: -p -r lib/ *-runner.jar
+          value: -p -r *-runner.jar
         - name: MAVEN_ARGS
-          value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
+          value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
           kind: ImageStreamTag
           name: openjdk-11:latest

--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -7,11 +7,8 @@ quarkus.infinispan-client.auth-password=qe
 quarkus.infinispan-client.sasl-mechanism=PLAIN
 quarkus.infinispan-client.client-intelligence=BASIC
 
-# TODO: remove workaround for https://github.com/quarkusio/quarkus/issues/14525
-quarkus.openshift.env.vars.smallrye-config-locations=/deployments/config
-
 # Where the app can read the trust store from when it runs
-quarkus.infinispan-client.trust-store=/mnt/clientcerts
+quarkus.infinispan-client.trust-store=/mnt/app-secret/clientcerts
 
 # trust store password
 quarkus.infinispan-client.trust-store-password=password
@@ -19,14 +16,10 @@ quarkus.infinispan-client.trust-store-password=password
 # trust store type
 quarkus.infinispan-client.trust-store-type=JKS
 
-# which secret to mount, and where to mount it
-quarkus.openshift.mounts.my-volume.path=/mnt
-quarkus.openshift.secret-volumes.my-volume.secret-name=clientcerts
-
 # instructs quarkus to build and deploy to kubernetes/openshift, and to trust the Kubernetes API since we're using self-signed
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # configmap settings
-quarkus.openshift.config-map-volumes.app-config.config-map-name=infinispan-config
-quarkus.openshift.mounts.app-config.path=/deployments/config
+quarkus.openshift.app-secret=clientcerts
+quarkus.openshift.app-config-map=infinispan-config

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
@@ -5,6 +5,9 @@
 %local.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/api
 
 kafka.bootstrap.servers=kafka-broker-1:9092
+# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+quarkus.reactive-messaging.health.enabled=false
+
 mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://registry-service:8081/api
 
 mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka

--- a/messaging/kafka-streams-reactive-messaging/pom.xml
+++ b/messaging/kafka-streams-reactive-messaging/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
@@ -7,6 +7,9 @@ producer.loginUrls=redhat/login,inditex/login,santander/login,bbva/login
 
 kafka.bootstrap.servers=kafka-broker-1:9092
 
+# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+quarkus.reactive-messaging.health.enabled=false
+
 mp.messaging.outgoing.login-http-response-values.connector=smallrye-kafka
 mp.messaging.outgoing.login-http-response-values.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.login-http-response-values.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/micrometer/prometheus-kafka/src/main/resources/application.properties
+++ b/micrometer/prometheus-kafka/src/main/resources/application.properties
@@ -1,4 +1,7 @@
 kafka.bootstrap.servers=kafka-broker-1:9092
+# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+quarkus.reactive-messaging.health.enabled=false
+
 mp.messaging.outgoing.alerts-source.connector=smallrye-kafka
 mp.messaging.outgoing.alerts-source.topic=alerts-target
 mp.messaging.outgoing.alerts-source.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.11.5.Final</version.quarkus>
+        <version.quarkus>1.12.0.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.2</version.testcontainers>
     </properties>
@@ -297,7 +297,7 @@
             <properties>
                 <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
                 <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                <version.qpid-jms>0.22.0</version.qpid-jms>
+                <version.qpid-jms>0.23.0</version.qpid-jms>
                 <version.quarkus>999-SNAPSHOT</version.quarkus>
             </properties>
             <dependencyManagement>
@@ -322,7 +322,9 @@
 
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11</quarkus.native.builder-image>
+                <!-- TODO: Can't use `ubi-quarkus-mandrel` image due to https://github.com/graalvm/mandrel/issues/218 -->
+                <!-- <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Final-java11</quarkus.native.builder-image> -->
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.0-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
                 <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -322,9 +322,7 @@
 
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <!-- TODO: Can't use `ubi-quarkus-mandrel` image due to https://github.com/graalvm/mandrel/issues/218 -->
-                <!-- <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Final-java11</quarkus.native.builder-image> -->
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.0-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.0-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
                 <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.12.0.Final</version.quarkus>
+        <version.quarkus>1.12.2.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.2</version.testcontainers>
     </properties>


### PR DESCRIPTION
- Upgrade Quarkus to 1.12.2.Final
- Upgrade quarkus-qpid-jms to 0.23.0
- Removed workaround for https://github.com/quarkusio/quarkus/issues/14525
- Added commit to update the TODO apps. Cherry-pick for https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/222