### PR TITLE
Coverage non-application-root-path feature

### DIFF
--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -1,10 +1,14 @@
 
 quarkus.application.name=test-http-advanced
 quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=/q
+quarkus.http.redirect-to-non-application-root-path=true
+
+#quarkus.smallrye-metrics.path=/metricas
 quarkus.http.port=8081
 
 # enable swagger-ui on prod mode in order to test swagger-ui endpoint redirection to /q/swagger-ui
-quarkus.swagger-ui.always-include=true 
+quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 
 quarkus.kubernetes.deployment-target=openshift

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -136,6 +136,7 @@ public abstract class AbstractHttpTest {
 
         for (String endpoint : endpoints) {
             given().redirects().follow(false)
+                    .log().uri()
                     .expect().
                     statusCode(301).
                     header("Location", containsString("/q" + endpoint)).


### PR DESCRIPTION
# How to run this test

* Clone and compile Quarkus [branch](https://github.com/kenfinnigan/quarkus/tree/non-app-endpoints)
* run ` mvn test -Dquarkus-core-only -Dquarkus.platform.version=999-SNAPSHOT -fae -pl http/http-advanced/`