### PR TITLE
http-advanced: wrong app endpoint path format

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractHttpTest {
     @DisplayName("Http/2 Server test")
     public void http2Server() throws InterruptedException, URISyntaxException {
         CountDownLatch done = new CountDownLatch(1);
-        Uni<JsonObject> content = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions()).getAbs(getAppEndpoint() + "/hello")
+        Uni<JsonObject> content = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions()).getAbs(getAppEndpoint() + "hello")
                 .expect(ResponsePredicate.create(AbstractHttpTest::isHttp2x))
                 .expect(ResponsePredicate.status(Response.Status.OK.getStatusCode()))
                 .send().map(HttpResponse::bodyAsJsonObject)
@@ -161,7 +161,7 @@ public abstract class AbstractHttpTest {
     @Test
     public void vertxHttpClientRedirection() throws InterruptedException, URISyntaxException {
         CountDownLatch done = new CountDownLatch(1);
-        Uni<Integer> statusCode = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions()).getAbs(getAppEndpoint() + "/health")
+        Uni<Integer> statusCode = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions()).getAbs(getAppEndpoint() + "health")
                 .send().map(HttpResponse::statusCode)
                 .ifNoItem().after(Duration.ofSeconds(TIMEOUT_SEC)).fail()
                 .onFailure().retry().atMost(RETRY);

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/HttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/HttpTest.java
@@ -13,6 +13,6 @@ public class HttpTest extends AbstractHttpTest {
 
     @Override
     protected String getAppEndpoint() {
-        return String.format("https://localhost:%d/api", appPort);
+        return String.format("https://localhost:%d/api/", appPort);
     }
 }


### PR DESCRIPTION
We were setting wrong paths that don't match Keycloak disabled patterns 

Example:
`http://localhost:8080/api//hello`

**Note:** there are two slash