### PR TITLE
Workshop-super-hero opc additional resources bugfix

### DIFF
--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -32,7 +32,7 @@ items:
       sourceStrategy:
         env:
         - name: ARTIFACT_COPY_ARGS
-          value: -p -r lib/ *-runner.jar
+          value: -p -r quarkus-app/*
         - name: MAVEN_ARGS
           value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
@@ -61,7 +61,7 @@ items:
           image: quarkus-workshop-hero:latest
           env:
           - name: ARTIFACT_COPY_ARGS
-            value: -p -r lib/ *-runner.jar
+            value: -p -r lib/ *
           - name: QUARKUS_DATASOURCE_JDBC_URL
             value: jdbc:postgresql://heroes-database:5432/heroes-database
           - name: QUARKUS_HTTP_PORT

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -32,7 +32,7 @@ items:
         sourceStrategy:
           env:
             - name: ARTIFACT_COPY_ARGS
-              value: -p -r lib/ *-runner.jar
+              value: -p -r quarkus-app/*
             - name: MAVEN_ARGS
               value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
           from:
@@ -61,7 +61,7 @@ items:
               image: quarkus-workshop-villain:latest
               env:
                 - name: ARTIFACT_COPY_ARGS
-                  value: -p -r lib/ *-runner.jar
+                  value: -p -r lib/*
                 - name: QUARKUS_DATASOURCE_JDBC_URL
                   value: jdbc:postgresql://villains-database:5432/villains-database
                 - name: QUARKUS_HTTP_PORT


### PR DESCRIPTION
Looks that have changed how workshop-super hero packages their application, so we made some build changes accordingly.

Changes:

There is no "-runner.jar" anymore instead we found a rest-hero-01.jar
This, not a über-jar (fatJar), so his dependencies are located on quarkus-app/lib