### PR TITLE
Update TODO app to allow use concrete quarkus version and product

### DIFF
--- a/external-applications/todo-demo-app/pom.xml
+++ b/external-applications/todo-demo-app/pom.xml
@@ -25,6 +25,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
+++ b/external-applications/todo-demo-app/src/test/java/io/quarkus/ts/openshift/todo/demo/app/TodoDemoAppOpenShiftIT.java
@@ -14,6 +14,7 @@ import static io.restassured.RestAssured.when;
 @OpenShiftTest(strategy = ManualDeploymentStrategy.class)
 @CustomAppMetadata(appName = "todo-demo-app", httpRoot = "/", knownEndpoint = "/")
 @AdditionalResources("classpath:openjdk-11.yaml")
+@AdditionalResources("classpath:deployments/maven/s2i-maven-settings.yaml")
 @AdditionalResources("classpath:todo-demo-app.yaml")
 public class TodoDemoAppOpenShiftIT {
     @TestResource

--- a/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
+++ b/external-applications/todo-demo-app/src/test/resources/todo-demo-app.yaml
@@ -22,12 +22,18 @@ items:
       git:
         uri: https://github.com/quarkusio/todo-demo-app.git
       type: Git
+      configMaps:
+      - configMap:
+          name: settings-mvn
+        destinationDir: "configuration"
     strategy:
       type: Source
       sourceStrategy:
         env:
         - name: ARTIFACT_COPY_ARGS
           value: -p -r lib/ *-runner.jar
+        - name: MAVEN_ARGS
+          value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
           kind: ImageStreamTag
           name: openjdk-11:latest
@@ -52,9 +58,6 @@ items:
         containers:
         - name: todo-demo-app
           image: todo-demo-app:latest
-          env:
-          - name: ARTIFACT_COPY_ARGS
-            value: -p -r lib/ *-runner.jar
           ports:
           - containerPort: 8080
             protocol: TCP


### PR DESCRIPTION
Update the TODO app to allow using a concrete Quarkus version for upstream and product.
This PR is related to https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/205 (same work for for other modules).