### PR TITLE
Fix http-advanced tests

### DIFF
--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -53,9 +53,9 @@ quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
 quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
-quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED        
+quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
-quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED        
+quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.metrics.path=/api/metrics/*
 quarkus.keycloak.policy-enforcer.paths.metrics.enforcement-mode=DISABLED

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -15,6 +15,7 @@ import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicateResult;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -177,7 +178,7 @@ public abstract class AbstractHttpTest {
     }
 
     protected String getAppEndpoint() {
-        return appEndpoint.toString();
+        return StringUtils.appendIfMissing(appEndpoint.toString(), "/");
     }
 
     private static ResponsePredicateResult isHttp2x(HttpResponse<Void> resp) {


### PR DESCRIPTION
The changes made in https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/218 (for Master) and https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/217 (for 1.11) are not working for all the Quarkus versions. To sum up:

- In OpenShift TS using 999-SNAPSHOT: it will work
- In OpenShift TS 1.11 (using 1.11.1.Final): it won't work
- In OpenShift TS 1.11 (setting up the version to 1.11.5.Final): it will work
- In OpenShift TS Master (using 1.11.1.Final): it won't work
- In OpenShift TS Master (using 1.12.0.Final): it won't work
- In OpenShift TS Master (using 1.12.1.Final): it will work

The root cause of the problem is this commit: https://github.com/quarkusio/quarkus/commit/e0f8ec94ef9b6882a60a4f7299c9db9b17893fe2. The changes were back-ported to 1.11.5, but is present in 1.11.1.Final and 1.12.0.Final.

This PR addresses the above inconsistency by adding the slash only if it does not include it and for OpenShift scenario only.