### PR TITLE
Upgrade to 1.11.5.Final version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.11.1.Final</version.quarkus>
+        <version.quarkus>1.11.5.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.2</version.testcontainers>
     </properties>
@@ -322,7 +322,7 @@
 
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Final-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
                 <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>


### PR DESCRIPTION
We need to upgrade to latest version, so we can continue verifying features that are part of the 1.11 branch.