### PR TITLE
Cover swagger ui redirection in http advanced module

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -127,11 +127,10 @@ public abstract class AbstractHttpTest {
     @Test
     @DisplayName("Non-application endpoint move to /q/")
     public void nonAppRedirections() {
-        //TODO QUARKUS-752: swagger-ui (quarkus.swagger-ui.always-include) is not supported by Native mode.
         List<String> endpoints = Arrays.asList(
                 "/openapi", "/metrics/base", "/metrics/application",
                 "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",
-                "/health/live", "/health"
+                "/health/live", "/health", "/swagger-ui"
         );
 
         for (String endpoint : endpoints) {


### PR DESCRIPTION
The issue https://github.com/quarkusio/quarkus/issues/14911 has been marked as resolved and this PR is about to cover the redirection to swagger ui.