### PR TITLE
Make http-advanced test to work when "/" is not appended in the url

### DIFF
--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -49,9 +49,9 @@ quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
 quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
-quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED        
+quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
-quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED        
+quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.metrics.path=/api/metrics/*
 quarkus.keycloak.policy-enforcer.paths.metrics.enforcement-mode=DISABLED

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -15,6 +15,7 @@ import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicateResult;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -176,7 +177,7 @@ public abstract class AbstractHttpTest {
     }
 
     protected String getAppEndpoint() {
-        return appEndpoint.toString();
+        return StringUtils.appendIfMissing(appEndpoint.toString(), "/");
     }
 
     private static ResponsePredicateResult isHttp2x(HttpResponse<Void> resp) {


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/224 into 1.11