### PR TITLE
[master] Use absolute path for Maven settings in S2I builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ spec:
     configMaps:
     - configMap:
         name: settings-mvn
-      destinationDir: "configuration"
+      destinationDir: "/configuration"
   strategy:
     type: Source
     sourceStrategy:
@@ -436,7 +436,7 @@ spec:
       - name: ARTIFACT_COPY_ARGS
         value: -p -r lib/ *-runner.jar
       - name: MAVEN_ARGS
-        value: -s /opt/app-root/src/configuration/settings.xml
+        value: -s /configuration/settings.xml
       from:
         kind: ImageStreamTag
         name: openjdk-11:latest

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/hero.yaml
@@ -26,7 +26,7 @@ items:
       configMaps:
       - configMap:
           name: settings-mvn
-        destinationDir: "configuration"
+        destinationDir: "/configuration"
     strategy:
       type: Source
       sourceStrategy:
@@ -34,7 +34,7 @@ items:
         - name: ARTIFACT_COPY_ARGS
           value: -p -r lib/ *-runner.jar
         - name: MAVEN_ARGS
-          value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
+          value: -s /configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
         from:
           kind: ImageStreamTag
           name: openjdk-11:latest

--- a/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/resources/villain.yaml
@@ -26,7 +26,7 @@ items:
         configMaps:
         - configMap:
             name: settings-mvn
-          destinationDir: "configuration"
+          destinationDir: "/configuration"
       strategy:
         type: Source
         sourceStrategy:
@@ -34,7 +34,7 @@ items:
             - name: ARTIFACT_COPY_ARGS
               value: -p -r lib/ *-runner.jar
             - name: MAVEN_ARGS
-              value: -s /opt/app-root/src/configuration/settings.xml -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
+              value: -s /configuration/settings.xml -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
           from:
             kind: ImageStreamTag
             name: openjdk-11:latest


### PR DESCRIPTION
The path `/opt/app-root/src` depends on the image that OCP uses to build. In OCP 4+ and 3.11, the working dir differs:
- For OCP 3, the path is `/tmp/src`
- For OCP 4+, the path is `/opt/app-root/src`

In order to support both platforms, this PR aims to use absolute path instead.
I've verified that this is now working with OCP 3 and OCP 4.

This PR needs to be backported to 1.11.