### PR TITLE
Non-application endpoint could skip keycloak-authz, by disabling `/q/*`

### DIFF
--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -43,19 +43,9 @@ quarkus.grpc.clients.hello.host=localhost
 
 # authZ
 quarkus.keycloak.policy-enforcer.enable=true
-# QUARKUS-720: workaround, move on from health.path=/health/* to health.path=/q/health/*
+# Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead
 quarkus.keycloak.policy-enforcer.paths.health-redirection.path=/api/q/*
 quarkus.keycloak.policy-enforcer.paths.health-redirection.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.health.path=/api/health/*
-quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
-quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
-quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
-quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
-quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
-quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.metrics.path=/api/metrics/*
 quarkus.keycloak.policy-enforcer.paths.metrics.enforcement-mode=DISABLED
@@ -65,6 +55,19 @@ quarkus.keycloak.policy-enforcer.paths.openapi.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.swagger-ui.path=/api/swagger-ui/*
 quarkus.keycloak.policy-enforcer.paths.swagger-ui.enforcement-mode=DISABLED
+
+quarkus.keycloak.policy-enforcer.paths.health.path=/api/health/*
+quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
+
+quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
+quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
+
+# Application endpoints
+quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
+quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
+
+quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
+quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED
 
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractHttpTest {
     public void nonAppRedirections() {
         //TODO QUARKUS-752: swagger-ui (quarkus.swagger-ui.always-include) is not supported by Native mode.
         List<String> endpoints = Arrays.asList(
-                "/openapi", "/metrics/base", "/metrics/application",
+                "/openapi", "/swagger-ui", "/metrics/base", "/metrics/application",
                 "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",
                 "/health/live", "/health"
         );

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -127,7 +127,6 @@ public abstract class AbstractHttpTest {
     @Test
     @DisplayName("Non-application endpoint move to /q/")
     public void nonAppRedirections() {
-        //TODO QUARKUS-752: swagger-ui (quarkus.swagger-ui.always-include) is not supported by Native mode.
         List<String> endpoints = Arrays.asList(
                 "/openapi", "/swagger-ui", "/metrics/base", "/metrics/application",
                 "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",

--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -7,8 +7,7 @@ quarkus.oidc.credentials.secret=test-application-client-secret
 quarkus.oidc.token.lifespan-grace=60
 
 quarkus.keycloak.policy-enforcer.enable=true
-# QUARKUS-720: workaround, move on from health.path=/health/* to health.path=/q/health/*
-quarkus.keycloak.policy-enforcer.paths.health.path=/q/health/*
+quarkus.keycloak.policy-enforcer.paths.health.path=/q/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 
 quarkus.openshift.expose=true


### PR DESCRIPTION
keycloak-authz: Non-application endpoint could be skipped by disabling `/q/*`
http-advanced: we still skip all non-application endpoints because we want to force a redirection. 