### PR TITLE
Explicitly making app-metadata/runtime use versioned quarkus-bootstrap-maven-plugin.

### DIFF
--- a/app-metadata/runtime/pom.xml
+++ b/app-metadata/runtime/pom.xml
@@ -28,6 +28,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${version.plugin.quarkus}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Fixing the issue when sometimes a wrong version of `quarkus-bootstrap-maven-plugin` is used with unpopulated repositories.