### PR TITLE
Remove executions section in quarkus-bootstrap-maven-plugin

### DIFF
--- a/app-metadata/runtime/pom.xml
+++ b/app-metadata/runtime/pom.xml
@@ -29,16 +29,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                 <version>${version.plugin.quarkus}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>extension-descriptor</goal>
-                        </goals>
-                        <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The executions section is making the build of the app module to fail when using quarkus 999-SNAPSHOT.
Looking at Quarkus upstream, they are not using this executions section.