### PR TITLE
Fix grpc port collision on test

### DIFF
--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -40,6 +40,7 @@ io.quarkus.ts.openshift.http.clients.HttpVersionClientServiceAsync/mp-rest/trust
 
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001
 
 # authZ
 quarkus.keycloak.policy-enforcer.enable=true


### PR DESCRIPTION
We had some port conflicts in OpenShift TS related to gRPC.
This change is based on https://github.com/quarkus-qe/beefy-scenarios/pull/153 and it should not affect OpenShift tests.