### PR TITLE
Readiness probe adjustment.

### DIFF
--- a/config-secret/api-server/src/main/resources/application.properties
+++ b/config-secret/api-server/src/main/resources/application.properties
@@ -8,3 +8,7 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 %test.quarkus.kubernetes-config.enabled=false
 # TODO: remove once https://github.com/quarkusio/quarkus/issues/11968 is resolved
 %test.quarkus.kubernetes-config.secrets.enabled=false
+
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -4,3 +4,7 @@ quarkus.openshift.app-secret=app-config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
+
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/configmap/api-server/src/main/resources/application.properties
+++ b/configmap/api-server/src/main/resources/application.properties
@@ -5,3 +5,7 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.hello.message=Hello, %s!
 %test.quarkus.kubernetes-config.enabled=false
+
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/configmap/file-system/src/main/resources/application.properties
+++ b/configmap/file-system/src/main/resources/application.properties
@@ -10,3 +10,7 @@ quarkus.openshift.env.vars.smallrye-config-locations=/deployments/config
 
 # the application binary resides in /home/quarkus with quarkus/ubi-quarkus-native-binary-s2i
 %native.quarkus.openshift.mounts.app-config.path=/home/quarkus/config
+
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -74,3 +74,7 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
+
+quarkus.kubernetes.readiness-probe.period=5s
+quarkus.kubernetes.readiness-probe.initial-delay=0s
+quarkus.kubernetes.readiness-probe.failure-threshold=5

--- a/http/http-minimum/src/main/resources/application.properties
+++ b/http/http-minimum/src/main/resources/application.properties
@@ -3,3 +3,7 @@ quarkus.http.root-path=/api
 quarkus.kubernetes.deployment-target=openshift
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
+
+quarkus.kubernetes.readiness-probe.period=5s
+quarkus.kubernetes.readiness-probe.initial-delay=0s
+quarkus.kubernetes.readiness-probe.failure-threshold=5

--- a/messaging/amqp-reactive/src/main/resources/application.properties
+++ b/messaging/amqp-reactive/src/main/resources/application.properties
@@ -12,3 +12,8 @@ mp.messaging.outgoing.generated-price.address=prices
 # Configure the AMQP connector to read from the `prices` queue
 mp.messaging.incoming.prices.connector=smallrye-amqp
 mp.messaging.incoming.prices.durable=true
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -9,3 +9,8 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 quarkus.transaction-manager.default-transaction-timeout=5s
 quarkus.transaction-manager.node-name=artemis-666
+
+# Openshift
+quarkus.kubernetes.readiness-probe.period=5s
+quarkus.kubernetes.readiness-probe.initial-delay=0s
+quarkus.kubernetes.readiness-probe.failure-threshold=5

--- a/messaging/artemis/src/main/resources/application.properties
+++ b/messaging/artemis/src/main/resources/application.properties
@@ -6,3 +6,8 @@ quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/application.properties
@@ -23,4 +23,8 @@ mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.kubernetes.readiness-probe.period=5s
+quarkus.kubernetes.readiness-probe.initial-delay=0s
+quarkus.kubernetes.readiness-probe.failure-threshold=5

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/application.properties
@@ -36,4 +36,8 @@ kafka-streams.consumer.heartbeat.interval.ms=80
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/messaging/qpid/src/main/resources/application.properties
+++ b/messaging/qpid/src/main/resources/application.properties
@@ -6,3 +6,8 @@ quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 quarkus.qpid-jms.url=amqp://amq-broker-amqp:5672
 quarkus.qpid-jms.username=quarkus
 quarkus.qpid-jms.password=quarkus
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/micrometer/prometheus-kafka/src/main/resources/application.properties
+++ b/micrometer/prometheus-kafka/src/main/resources/application.properties
@@ -9,6 +9,10 @@ mp.messaging.outgoing.alerts-source.value.serializer=org.apache.kafka.common.ser
 mp.messaging.incoming.alerts-target.connector=smallrye-kafka
 mp.messaging.incoming.alerts-target.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
+# Openshift
 quarkus.openshift.labels.app-with-metrics=quarkus-app
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/micrometer/prometheus/src/main/resources/application.properties
+++ b/micrometer/prometheus/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 quarkus.openshift.labels.app-with-metrics=quarkus-app
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/microprofile/src/main/resources/application.properties
+++ b/microprofile/src/main/resources/application.properties
@@ -5,8 +5,12 @@ quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1
 quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces
 
+# Openshift
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 
 %test.io.quarkus.ts.openshift.microprofile.HelloClient/mp-rest/url=http://localhost:8081/
 %test.quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces

--- a/scaling/src/main/resources/application.properties
+++ b/scaling/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 quarkus.application.name=test-scaling
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/basic/src/main/resources/application.properties
+++ b/security/basic/src/main/resources/application.properties
@@ -7,5 +7,9 @@ quarkus.security.users.embedded.users.isaac=N3wt0N
 quarkus.security.users.embedded.roles.albert=admin,user
 quarkus.security.users.embedded.roles.isaac=user
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/https-1way/src/main/resources/application.properties
+++ b/security/https-1way/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 quarkus.http.ssl.certificate.key-store-file=server-keystore.pkcs12
 quarkus.http.ssl.certificate.key-store-password=server-password
 quarkus.http.insecure-requests=redirect
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/https-2way-authz/src/main/resources/application.properties
+++ b/security/https-2way-authz/src/main/resources/application.properties
@@ -8,3 +8,8 @@ quarkus.http.ssl.client-auth=request
 quarkus.http.auth.policy.users-only.roles-allowed=user
 quarkus.http.auth.permission.secured-urls.paths=/secured/*
 quarkus.http.auth.permission.secured-urls.policy=users-only
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/https-2way/src/main/resources/application.properties
+++ b/security/https-2way/src/main/resources/application.properties
@@ -3,3 +3,8 @@ quarkus.http.ssl.certificate.key-store-password=server-password
 quarkus.http.ssl.certificate.trust-store-file=server-truststore.pkcs12
 quarkus.http.ssl.certificate.trust-store-password=server-password
 quarkus.http.ssl.client-auth=required
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/jwt/src/main/resources/application.properties
+++ b/security/jwt/src/main/resources/application.properties
@@ -6,3 +6,8 @@ quarkus.security.deny-unannotated-members=true
 
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -10,5 +10,9 @@ quarkus.keycloak.policy-enforcer.enable=true
 quarkus.keycloak.policy-enforcer.paths.health.path=/q/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-jwt/src/main/resources/application.properties
+++ b/security/keycloak-jwt/src/main/resources/application.properties
@@ -9,5 +9,9 @@ quarkus.oidc.token.lifespan-grace=60
 quarkus.oidc.application-type=web-app
 quarkus.oidc.roles.source=accesstoken
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-multitenant/src/main/resources/application.properties
+++ b/security/keycloak-multitenant/src/main/resources/application.properties
@@ -24,5 +24,9 @@ quarkus.oidc.jwt-tenant.application-type=web-app
 quarkus.oidc.jwt-tenant.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.jwt-tenant.roles.source=accesstoken
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-oauth2/src/main/resources/application.properties
+++ b/security/keycloak-oauth2/src/main/resources/application.properties
@@ -5,5 +5,10 @@ quarkus.oauth2.client-id=test-application-client
 quarkus.oauth2.client-secret=test-application-client-secret
 quarkus.oauth2.role-claim=roles
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
+
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-oidc-client/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client/src/main/resources/application.properties
@@ -32,5 +32,10 @@ quarkus.oidc-client.jwt-secret.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt-secret.client-id=test-application-client-jwt
 quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
+
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak-webapp/src/main/resources/application.properties
+++ b/security/keycloak-webapp/src/main/resources/application.properties
@@ -14,5 +14,10 @@ quarkus.oidc.logout.path=/logout
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
+# Openshift
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
+
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/security/keycloak/src/main/resources/application.properties
+++ b/security/keycloak/src/main/resources/application.properties
@@ -6,5 +6,10 @@ quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 5 seconds of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=5
 
+# Openshift
+
 quarkus.openshift.expose=true
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/sql-db/app/src/test/resources/application.properties
+++ b/sql-db/app/src/test/resources/application.properties
@@ -6,3 +6,8 @@
 %test.quarkus.datasource.jdbc.url=jdbc:h2:mem:mydb
 %test.quarkus.datasource.username=sa
 %test.quarkus.datasource.password=sa
+
+# Openshift
+%test.quarkus.openshift.readiness-probe.period=5s
+%test.quarkus.openshift.readiness-probe.initial-delay=0s
+%test.quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/mariadb/src/main/resources/application.properties
+++ b/sql-db/mariadb/src/main/resources/application.properties
@@ -21,3 +21,8 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 # we're not using MariaDB 10.3 yet :-(
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/mssql/src/main/resources/application.properties
+++ b/sql-db/mssql/src/main/resources/application.properties
@@ -19,3 +19,8 @@ quarkus.datasource.password=${DB_PASSWORD}
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -37,3 +37,8 @@ quarkus.hibernate-orm."vegetables".database.generation=drop-and-create
 quarkus.hibernate-orm."vegetables".sql-load-script=import-vegetables.sql
 quarkus.hibernate-orm."vegetables".datasource=vegetables
 quarkus.hibernate-orm."vegetables".packages=io.quarkus.ts.openshift.sqldb.multiplepus.model.vegetable
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/mysql/src/main/resources/application.properties
+++ b/sql-db/mysql/src/main/resources/application.properties
@@ -19,3 +19,8 @@ quarkus.datasource.password=${DB_PASSWORD}
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/postgresql/src/main/resources/application.properties
+++ b/sql-db/postgresql/src/main/resources/application.properties
@@ -19,3 +19,8 @@ quarkus.datasource.password=${DB_PASSWORD}
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# Openshift
+quarkus.openshift.readiness-probe.period=5s
+quarkus.openshift.readiness-probe.initial-delay=0s
+quarkus.openshift.readiness-probe.failure-threshold=5


### PR DESCRIPTION
Currently, we are not setting `quarkus.openshift.readiness-probe.period` so the default value (30 sec) is getting in place.
This default value add some extra time that is not needed, especially on test that is increasing and decreasing the number of pods.