### PR TITLE
App Metadata needs runtime dependencies of vertx-http

### DIFF
--- a/app-metadata/runtime/pom.xml
+++ b/app-metadata/runtime/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
At the moment, the bootstrap maven plugin is failing when using 999-SNAPSHOT version.