### PR TITLE
Deploy in parallel several resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ quarkus.my.property=${KEYCLOAK_HTTP_URL:default_value}
 
 Further information about usage of configuration in [here](https://quarkus.io/guides/config-reference#combine-property-env-var).
 
+**Note:** In case that you have several unrelated additional resources as Redis and postgres together in the same application, you can deploy those resources in parallel by adding `@ParallelAdditionalResourcesEnabled` annotation. Note that this label applies to all additional resources of this scenario.  
+
 ### Running tests in ephemeral namespaces
 
 By default, the test framework expects that the user is logged into an OpenShift project, and that project is used for all tests.

--- a/common/src/main/java/io/quarkus/ts/openshift/common/ParallelAdditionalResourcesEnabled.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/ParallelAdditionalResourcesEnabled.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.openshift.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allow you to deploy several additional resources at once.
+ * */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParallelAdditionalResourcesEnabled {
+}

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
@@ -4,6 +4,7 @@ import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.ParallelAdditionalResourcesEnabled;
 import io.quarkus.ts.openshift.common.deploy.ManualDeploymentStrategy;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import org.junit.jupiter.api.MethodOrderer;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @AdditionalResources("classpath:hero.yaml")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @OnlyIfConfigured("ts.authenticated-registry")
+@ParallelAdditionalResourcesEnabled
 public class HeroesOpenShiftIT {
 
     @TestResource

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
@@ -4,6 +4,7 @@ import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.CustomAppMetadata;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.ParallelAdditionalResourcesEnabled;
 import io.quarkus.ts.openshift.common.deploy.ManualDeploymentStrategy;
 import io.quarkus.ts.openshift.common.injection.TestResource;
 import org.hamcrest.core.Is;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @AdditionalResources("classpath:villain.yaml")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @OnlyIfConfigured("ts.authenticated-registry")
+@ParallelAdditionalResourcesEnabled
 public class VillainsOpenShiftIT {
 
     @TestResource

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/AmqStreamsOpenShiftIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/AmqStreamsOpenShiftIT.java
@@ -3,10 +3,12 @@ package io.quarkus.ts.openshift.messaging.kafka;
 import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.ParallelAdditionalResourcesEnabled;
 
 @OpenShiftTest
 @AdditionalResources("classpath:deployments/kafka/amq-streams.yaml")
 @AdditionalResources("classpath:deployments/kafka/apicurio.yaml")
 @OnlyIfConfigured("ts.authenticated-registry")
+@ParallelAdditionalResourcesEnabled
 public class AmqStreamsOpenShiftIT extends AbstractKafkaTest{
 }

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/StrimziKafkaAvroOpenShiftIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/StrimziKafkaAvroOpenShiftIT.java
@@ -2,9 +2,11 @@ package io.quarkus.ts.openshift.messaging.kafka;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.ParallelAdditionalResourcesEnabled;
 
 @OpenShiftTest
 @AdditionalResources("classpath:deployments/kafka/strimzi.yaml")
 @AdditionalResources("classpath:deployments/kafka/apicurio.yaml")
+@ParallelAdditionalResourcesEnabled
 public class StrimziKafkaAvroOpenShiftIT extends AbstractKafkaTest{
 }


### PR DESCRIPTION
Goal: reduce test suite execution time.
Desc: Deploy in parallel additional resources

Nowadays we are deploying in Openshift-ts following a blocking sequential steps:

```
CreateEphimeralNs -> delpoyAdditionalResources(you could have more than one and all of them are blocking) ->  runPublicStaticVoidMethods -> deploy application -> setupRestAssured -> readinesProbe
```

Porposal:

Block One: setup ecosystem
```
CreateEphimeralNs ->
                       - delpoyAdditionalResources
                                           - delpoyAdditionalResources 1
                                           - delpoyAdditionalResources 2
                                           - delpoyAdditionalResources 3
                      - runPublicStaticVoidMethods
```

Block Two(Depends on block one): setup application

```
deployApplication -> setup Rest assured -> readinesProbe
```

Also, you will have a little summary of deployed additional resources
Example:

```
--- Summary: deployAdditionalResources ---
classpath:deployments/kafka/amq-streams.yaml ✓
classpath:deployments/kafka/apicurio.yaml ✓
--- end ---
```