### PR TITLE
Workaround: remove ansi dependency to workaround quarkus/issues/15953

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,10 +45,12 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
+        <!-- TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
         </dependency>
+         -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/common/src/main/java/io/quarkus/ts/openshift/common/AdditionalResourcesDeployed.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/AdditionalResourcesDeployed.java
@@ -15,8 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 
-import static org.fusesource.jansi.Ansi.ansi;
-
 final class AdditionalResourcesDeployed implements CloseableResource {
 
     private final String url;
@@ -36,7 +34,10 @@ final class AdditionalResourcesDeployed implements CloseableResource {
         Path tempFile = copyResourceIntoTempFile(url);
         ImageOverrides.apply(tempFile, oc);
 
-        System.out.println(ansi().a("deploying ").fgYellow().a(url).reset());
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("deploying ").fgYellow().a(url).reset());
+        System.out.println("deploying " + url);
+
         new Command("oc", "apply", "-f", tempFile.toString()).runAndWait();
 
         List<HasMetadata> deployedResources = oc.load(Files.newInputStream(tempFile)).get();
@@ -68,7 +69,9 @@ final class AdditionalResourcesDeployed implements CloseableResource {
             return;
         }
 
-        System.out.println(ansi().a("undeploying ").fgYellow().a(url).reset());
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("undeploying ").fgYellow().a(url).reset());
+        System.out.println("undeploying " + url);
         new Command("oc", "delete", "-f", file.toString(), "--ignore-not-found").runAndWait();
         Files.delete(file);
     }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/Command.java
@@ -11,8 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import static org.fusesource.jansi.Ansi.ansi;
-
 public class Command {
     private final String description;
     private final List<String> command;
@@ -46,7 +44,9 @@ public class Command {
     }
 
     public void runAndWait() throws IOException, InterruptedException {
-        System.out.println(ansi().a("running ").fgYellow().a(String.join(" ", command)).reset());
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("running ").fgYellow().a(String.join(" ", command)).reset());
+        System.out.println("running " + String.join(" ", command));
         Process process = new ProcessBuilder()
                 .redirectErrorStream(true)
                 .command(command)
@@ -81,7 +81,9 @@ public class Command {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    System.out.println(ansi().fgCyan().a(description).reset().a("> ").a(line));
+                    // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+                    // System.out.println(ansi().fgCyan().a(description).reset().a("> ").a(line));
+                    System.out.println(description + "> " + line);
                 }
             } catch (IOException ignored) {
             }

--- a/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
@@ -47,7 +47,6 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import static org.fusesource.jansi.Ansi.ansi;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
 
 // TODO at this point, this class is close to becoming unreadable, and could use some refactoring.
@@ -175,7 +174,9 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
             EphemeralNamespace namespace = EphemeralNamespace.newWithRandomName();
             getStore(context).put(EphemeralNamespace.class.getName(), namespace);
 
-            System.out.println(ansi().a("using ephemeral namespace ").fgYellow().a(namespace.name).reset());
+            // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+            // System.out.println(ansi().a("using ephemeral namespace ").fgYellow().a(namespace.name).reset());
+            System.out.println("using ephemeral namespace " + namespace.name);
             new Command("oc", "new-project", namespace.name).runAndWait();
         }
     }
@@ -208,7 +209,9 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
         AppMetadata metadata = getAppMetadata(context);
 
         if (metadata.deploymentTarget.isEmpty() || !metadata.deploymentTarget.contains("knative")) {
-            System.out.println(ansi().a("using ").fgYellow().a("OpenShiftClient").reset().a(" to get the route"));
+            // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+            // System.out.println(ansi().a("using ").fgYellow().a("OpenShiftClient").reset().a(" to get the route"));
+            System.out.println("using OpenShiftClient to get the route");
 
             Route route = oc.routes().withName(metadata.appName).get();
             if (route == null) {
@@ -221,7 +224,9 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
                 RestAssured.baseURI = "http://" + route.getSpec().getHost();
             }
         } else {
-            System.out.println(ansi().a("using ").fgYellow().a("KnativeClient").reset().a(" to get the route"));
+            // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+            // System.out.println(ansi().a("using ").fgYellow().a("KnativeClient").reset().a(" to get the route"));
+            System.out.println("using KnativeClient to get the route");
 
             KnativeClient kn = oc.adapt(KnativeClient.class);
             io.fabric8.knative.serving.v1.Route knRoute = kn.routes().withName(metadata.appName).get();
@@ -239,8 +244,9 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
 
         if (testsFailed) {
             System.out.println("---------- OpenShiftTest failure ----------");
-            System.out.println(ansi().a("test ").fgYellow().a(context.getDisplayName()).reset()
-                    .a(" failed, showing current namespace status"));
+            // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+            // System.out.println(ansi().a("test ").fgYellow().a(context.getDisplayName()).reset().a(" failed, showing current namespace status"));
+            System.out.println("test " + context.getDisplayName() + " failed, showing current namespace status");
 
             onFailureActions.forEach(action -> this.runOnFailureAction(context, action));
         }
@@ -264,11 +270,16 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
         TestsStatus status = getTestsStatus(context);
         if (ephemeralNamespace != null) {
             if (RetainOnFailure.isEnabled() && status.failed) {
-                System.out.println(ansi().a("test ").fgYellow().a(context.getDisplayName()).reset()
-                        .a(" failed, keeping ephemeral namespace ").fgYellow().a(ephemeralNamespace.name).reset()
-                        .a(" intact"));
+                // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+                // System.out.println(ansi().a("test ").fgYellow().a(context.getDisplayName()).reset()
+                //       .a(" failed, keeping ephemeral namespace ").fgYellow().a(ephemeralNamespace.name).reset()
+                //       .a(" intact"));
+                System.out.println("test " + context.getDisplayName() + " failed, keeping ephemeral namespace "
+                        + ephemeralNamespace.name + " intact");
             } else {
-                System.out.println(ansi().a("dropping ephemeral namespace ").fgYellow().a(ephemeralNamespace.name).reset());
+                // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+                // System.out.println(ansi().a("dropping ephemeral namespace ").fgYellow().a(ephemeralNamespace.name).reset());
+                System.out.println("dropping ephemeral namespace " + ephemeralNamespace.name);
                 new Command("oc", "delete", "project", ephemeralNamespace.name).runAndWait();
             }
         }
@@ -306,9 +317,12 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        System.out.println(ansi().a("---------- running test ")
-                .fgYellow().a(context.getParent().map(ctx -> ctx.getDisplayName() + ".").orElse(""))
-                .a(context.getDisplayName()).reset().a(" ----------"));
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("---------- running test ")
+        //        .fgYellow().a(context.getParent().map(ctx -> ctx.getDisplayName() + ".").orElse(""))
+        //        .a(context.getDisplayName()).reset().a(" ----------"));
+        System.out.println("---------- running test " + context.getParent().map(ctx -> ctx.getDisplayName() + ".").orElse("")
+                + context.getDisplayName() + " ----------");
     }
 
     // ---
@@ -420,7 +434,9 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
             injectDependencies(action, context);
             action.execute();
         } catch (Exception ex) {
-            System.out.println(ansi().a("Error running post failure action. Caused by: " + ex).reset());
+            // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+            // System.out.println(ansi().a("Error running post failure action. Caused by: " + ex).reset());
+            System.out.println("Error running post failure action. Caused by: " + ex);
         }
     }
 

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
-import static org.fusesource.jansi.Ansi.ansi;
 
 public final class AwaitUtil {
     private final OpenShiftClient oc;
@@ -28,7 +27,9 @@ public final class AwaitUtil {
     }
 
     public void awaitImageStream(String imageStream) {
-        System.out.println(ansi().a("waiting for image stream ").fgYellow().a(imageStream).reset().a(" to populate"));
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("waiting for image stream ").fgYellow().a(imageStream).reset().a(" to populate"));
+        System.out.println("waiting for image stream " + imageStream + " to populate");
         await().atMost(DefaultTimeout.getMinutes(), TimeUnit.MINUTES).until(imageStreamHasTags(oc, imageStream));
     }
 
@@ -44,8 +45,10 @@ public final class AwaitUtil {
                 oc.apps().deployments().withName(metadata.appName).get()
         ));
 
-        System.out.println(ansi().a("waiting for route ").fgYellow().a(metadata.appName).reset()
-                .a(" to start responding at ").fgYellow().a(metadata.knownEndpoint).reset());
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("waiting for route ").fgYellow().a(metadata.appName).reset()
+        //        .a(" to start responding at ").fgYellow().a(metadata.knownEndpoint).reset());
+        System.out.println("waiting for route " + metadata.appName + " to start responding at " + metadata.knownEndpoint);
         await().ignoreExceptions().atMost(DefaultTimeout.getMinutes(), TimeUnit.MINUTES).untilAsserted(() -> {
             given()
                     // known endpoint is already httpRoot-adjusted
@@ -62,8 +65,11 @@ public final class AwaitUtil {
                 .filter(Objects::nonNull)
                 .filter(it -> ReadinessUtil.isReadinessApplicable(it.getClass()))
                 .forEach(it -> {
-                    System.out.println(ansi().a("waiting for ").a(readableKind(it.getKind())).a(" ")
-                            .fgYellow().a(it.getMetadata().getName()).reset().a(" to become ready"));
+                    // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+                    // System.out.println(ansi().a("waiting for ").a(readableKind(it.getKind())).a(" ")
+                    //         .fgYellow().a(it.getMetadata().getName()).reset().a(" to become ready"));
+                    System.out.println("waiting for " + readableKind(it.getKind()) + " " + it.getMetadata().getName()
+                            + " to become ready");
                     await().pollInterval(1, TimeUnit.SECONDS)
                            .atMost(DefaultTimeout.getMinutes(), TimeUnit.MINUTES)
                            .until(() -> {

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
-import static org.fusesource.jansi.Ansi.ansi;
 
 public final class OpenShiftUtil {
     private final OpenShiftClient oc;
@@ -52,8 +51,10 @@ public final class OpenShiftUtil {
     }
 
     public void scale(String deploymentConfigName, int replicas, long timeout) {
-        System.out.println(ansi().a("scaling ").fgYellow().a(deploymentConfigName).reset()
-                .a(" to ").fgYellow().a(replicas).reset().a(" replica(s)"));
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("scaling ").fgYellow().a(deploymentConfigName).reset()
+        //        .a(" to ").fgYellow().a(replicas).reset().a(" replica(s)"));
+        System.out.println("scaling " + deploymentConfigName + " to " + replicas + " replica(s)");
 
         oc.deploymentConfigs()
                 .inNamespace(oc.getNamespace())
@@ -71,8 +72,11 @@ public final class OpenShiftUtil {
     }
 
     public void awaitDeploymentReadiness(String deploymentConfigName, int expectedReplicas, long timeout) {
-        String waitingReadinessMsg = ansi().a("waiting for ").fgYellow().a(deploymentConfigName).reset()
-                .a(" to have exactly ").fgYellow().a(expectedReplicas).reset().a(" ready replica(s)").toString();
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // String waitingReadinessMsg = ansi().a("waiting for ").fgYellow().a(deploymentConfigName).reset()
+        //        .a(" to have exactly ").fgYellow().a(expectedReplicas).reset().a(" ready replica(s)").toString();
+        String waitingReadinessMsg = "waiting for " + deploymentConfigName + " to have exactly " + expectedReplicas
+                + " ready replica(s)";
 
         System.out.println(waitingReadinessMsg);
 
@@ -103,7 +107,9 @@ public final class OpenShiftUtil {
     }
 
     public void rolloutChanges(String deploymentConfigName) {
-        System.out.println(ansi().a("rolling out ").fgYellow().a(deploymentConfigName).reset());
+        // TODO: Workaround for issue: https://github.com/quarkusio/quarkus/issues/15953
+        // System.out.println(ansi().a("rolling out ").fgYellow().a(deploymentConfigName).reset());
+        System.out.println("rolling out " + deploymentConfigName);
 
         int replicas = countReadyReplicas(deploymentConfigName);
 


### PR DESCRIPTION
The issue https://github.com/quarkusio/quarkus/issues/15953 is blocking the OpenShift TS to be built. 
As a temporary workaround, I've removed the ansi dependency. Once https://github.com/quarkusio/quarkus/issues/15953 is fixed, we should revert these changes.