### PR TITLE
Upgrade to Quarkus 1.13.2.Final

### DIFF
--- a/configmap/file-system/src/main/resources/application.properties
+++ b/configmap/file-system/src/main/resources/application.properties
@@ -1,15 +1,8 @@
 quarkus.openshift.expose=true
-quarkus.openshift.config-map-volumes.app-config.config-map-name=app-config
-quarkus.openshift.mounts.app-config.path=/deployments/config
+quarkus.openshift.app-config-map=app-config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
-# TODO: remove workaround for https://github.com/quarkusio/quarkus/issues/14525
-quarkus.openshift.env.vars.smallrye-config-locations=/deployments/config
-
 %test.hello.message=Hello, %s!
-
-# the application binary resides in /home/quarkus with quarkus/ubi-quarkus-native-binary-s2i
-%native.quarkus.openshift.mounts.app-config.path=/home/quarkus/config
 
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s

--- a/external-applications/quarkus-workshop-super-heroes/pom.xml
+++ b/external-applications/quarkus-workshop-super-heroes/pom.xml
@@ -45,6 +45,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Building external apps in OpenShift can be quite slow when downloading Maven dependencies -->
+                        <ts.default-timeout>20</ts.default-timeout>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/external-applications/todo-demo-app/pom.xml
+++ b/external-applications/todo-demo-app/pom.xml
@@ -35,6 +35,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Building external apps in OpenShift can be quite slow when downloading Maven dependencies -->
+                        <ts.default-timeout>20</ts.default-timeout>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -40,6 +40,9 @@ io.quarkus.ts.openshift.http.clients.HttpVersionClientServiceAsync/mp-rest/trust
 
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
+## Use the same gRPC for prod and test
+quarkus.grpc.server.port=9000
+quarkus.grpc.server.test-port=${quarkus.grpc.server.port}
 
 # authZ
 quarkus.keycloak.policy-enforcer.enable=true

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
@@ -5,7 +5,9 @@
 %local.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/api
 
 kafka.bootstrap.servers=kafka-broker-1:9092
-# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+
+# Kafka Health Check readiness remains down until It's consumed the first time, so we need to disable it in OpenShift.
+# Related to https://github.com/quarkusio/quarkus/issues/15464
 quarkus.reactive-messaging.health.enabled=false
 
 mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://registry-service:8081/api

--- a/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
@@ -7,7 +7,8 @@ producer.loginUrls=redhat/login,inditex/login,santander/login,bbva/login
 
 kafka.bootstrap.servers=kafka-broker-1:9092
 
-# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+# Kafka Health Check readiness remains down until It's consumed the first time, so we need to disable it in OpenShift.
+# Related to https://github.com/quarkusio/quarkus/issues/15464
 quarkus.reactive-messaging.health.enabled=false
 
 mp.messaging.outgoing.login-http-response-values.connector=smallrye-kafka

--- a/micrometer/prometheus-kafka/src/main/resources/application.properties
+++ b/micrometer/prometheus-kafka/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 kafka.bootstrap.servers=kafka-broker-1:9092
-# TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
+
+# Kafka Health Check readiness remains down until It's consumed the first time, so we need to disable it in OpenShift.
+# Related to https://github.com/quarkusio/quarkus/issues/15464
 quarkus.reactive-messaging.health.enabled=false
 
 mp.messaging.outgoing.alerts-source.connector=smallrye-kafka

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.12.2.Final</version.quarkus>
+        <version.quarkus>1.13.2.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.3</version.testcontainers>
     </properties>


### PR DESCRIPTION
Changes:
- Remove workaround of issues/14525
- Changed TODO by comment for issues/15464
- Make sure we use the same gRPC port for running in prod and test (for backward compatibility)