### PR TITLE
[1.11] Add module to cover the Quickstart using S2i

### DIFF
--- a/external-applications/quickstart-using-s2i/pom.xml
+++ b/external-applications/quickstart-using-s2i/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.openshift</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>quickstart-using-s2i</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus OpenShift TS: Quickstart Using s2i</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.ts.openshift</groupId>
+            <artifactId>common</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Building external apps in OpenShift can be quite slow when downloading Maven dependencies -->
+                        <ts.default-timeout>20</ts.default-timeout>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/external-applications/quickstart-using-s2i/src/test/java/io/quarkus/ts/openshift/todo/demo/app/QuickstartUsingS2iOpenShiftIT.java
+++ b/external-applications/quickstart-using-s2i/src/test/java/io/quarkus/ts/openshift/todo/demo/app/QuickstartUsingS2iOpenShiftIT.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.openshift.todo.demo.app;
+
+import io.quarkus.ts.openshift.common.AdditionalResources;
+import io.quarkus.ts.openshift.common.CustomAppMetadata;
+import io.quarkus.ts.openshift.common.OpenShiftTest;
+import io.quarkus.ts.openshift.common.deploy.ManualDeploymentStrategy;
+import io.quarkus.ts.openshift.common.injection.TestResource;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static io.restassured.RestAssured.when;
+
+@OpenShiftTest(strategy = ManualDeploymentStrategy.class)
+@CustomAppMetadata(appName = "quickstart-using-s2i", httpRoot = "/", knownEndpoint = "/")
+@AdditionalResources("classpath:deployments/maven/s2i-maven-settings.yaml")
+@AdditionalResources("classpath:quickstart-using-s2i.yaml")
+public class QuickstartUsingS2iOpenShiftIT {
+    @TestResource
+    private URL url;
+
+    @Test
+    public void verify() {
+        when()
+                .get(url)
+        .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/external-applications/quickstart-using-s2i/src/test/resources/quickstart-using-s2i.yaml
+++ b/external-applications/quickstart-using-s2i/src/test/resources/quickstart-using-s2i.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: quickstart-using-s2i
+  spec:
+    lookupPolicy:
+      local: false
+
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    name: quickstart-using-s2i
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: quickstart-using-s2i:latest
+    source:
+      git:
+        uri: https://github.com/quarkusio/quarkus-quickstarts
+        ref: "1.11"
+      contextDir: "getting-started"
+      type: Git
+      configMaps:
+      - configMap:
+          name: settings-mvn
+        destinationDir: "/configuration"
+    strategy:
+      type: Source
+      sourceStrategy:
+        env:
+        - name: MAVEN_ARGS
+          value: -s /configuration/settings.xml -Dquarkus-plugin.version=${version.plugin.quarkus} -Dquarkus.platform.version=${version.quarkus} -Dquarkus.platform.group-id=${quarkus.platform.group-id} -Dquarkus.platform.artifact-id=${quarkus.platform.artifact-id} -DskipTests=true
+        from:
+          # This is the default JDK version when creating the quickstart from OpenShift Console
+          kind: ImageStreamTag
+          namespace: openshift
+          name: 'java:openjdk-11-el7'
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChange: {}
+
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    name: quickstart-using-s2i
+  spec:
+    replicas: 1
+    selector:
+      name: quickstart-using-s2i
+    template:
+      metadata:
+        labels:
+          name: quickstart-using-s2i
+      spec:
+        containers:
+        - name: quickstart-using-s2i
+          image: quickstart-using-s2i:latest
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+    test: false
+    triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - quickstart-using-s2i
+          from:
+            kind: ImageStreamTag
+            name: quickstart-using-s2i:latest
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: quickstart-using-s2i
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: quickstart-using-s2i
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: quickstart-using-s2i
+  spec:
+    to:
+      name: quickstart-using-s2i

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 
         <module>external-applications/todo-demo-app</module>
         <module>external-applications/quarkus-workshop-super-heroes</module>
+        <module>external-applications/quickstart-using-s2i</module>
 
         <module>deployment-strategies/quarkus</module>
     </modules>


### PR DESCRIPTION
This quickstart is part of OpenShift quickstarts.
More information in QUARKUS-975

Backport of https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/272