### PR TITLE
Configure Dependabot as GitHub App is going to be deprecated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/273