### PR TITLE
Enable test for Keycloak 7.4 and Quarkus Authorization extension

### DIFF
--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak73AuthzOpenShiftIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak73AuthzOpenShiftIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.openshift.security.keycloak.authz;
 
 import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
+import io.quarkus.ts.openshift.common.OnlyIfNotConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
 @OpenShiftTest
@@ -9,7 +10,6 @@ import io.quarkus.ts.openshift.common.OpenShiftTest;
 @AdditionalResources("classpath:keycloak-realm.yaml")
 @AdditionalResources("classpath:deployments/keycloak/deployment.yaml")
 @InjectRouteUrlIntoApp(route = "keycloak-plain", envVar = "KEYCLOAK_HTTP_URL")
-// Run this test always as for RH SSO 7.4 is not working. Related issue: https://github.com/quarkusio/quarkus/issues/14318
-// @OnlyIfNotConfigured("ts.authenticated-registry")
+@OnlyIfNotConfigured("ts.authenticated-registry")
 public class SecurityKeycloak73AuthzOpenShiftIT extends AbstractSecurityKeycloakAuthzOpenShiftIT {
 }

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak74AuthzOpenShiftIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/openshift/security/keycloak/authz/SecurityKeycloak74AuthzOpenShiftIT.java
@@ -1,13 +1,10 @@
 package io.quarkus.ts.openshift.security.keycloak.authz;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.ts.openshift.common.AdditionalResources;
 import io.quarkus.ts.openshift.common.InjectRouteUrlIntoApp;
 import io.quarkus.ts.openshift.common.OnlyIfConfigured;
 import io.quarkus.ts.openshift.common.OpenShiftTest;
 
-@Disabled("Caused by https://github.com/quarkusio/quarkus/issues/14318")
 @OpenShiftTest
 @AdditionalResources("classpath:deployments/keycloak/version-74.yaml")
 @AdditionalResources("classpath:keycloak-realm.yaml")


### PR DESCRIPTION
This is supposed to work in 999-SNAPSHOT and 1.11.7.DR1 (product), but not in 1.11.7.Final (community)