### PR TITLE
Quarkus 2.0.2.Final Upgrade

### DIFF
--- a/app-metadata/deployment/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadataCollector.java
+++ b/app-metadata/deployment/src/main/java/io/quarkus/ts/openshift/app/metadata/AppMetadataCollector.java
@@ -33,7 +33,7 @@ public class AppMetadataCollector {
         } else if (liveness.isPresent()) {
             knownEndpoint = liveness.get().getPath();
         } else {
-            knownEndpoint = httpRoot.adjustPath("/"); // TODO ?
+            knownEndpoint = httpRoot.resolvePath("/"); // TODO ?
         }
 
         String deploymentTarget = ConfigProvider.getConfig()

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,12 +55,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/OpenShiftTestExtension.java
@@ -262,7 +262,7 @@ final class OpenShiftTestExtension implements BeforeAllCallback, AfterAllCallbac
             Route route = oc.routes().withName(metadata.appName).get();
             if (route == null) {
                 throw new OpenShiftTestException(
-                        "Missing route " + metadata.appName + ", did you set quarkus.openshift.expose=true?");
+                        "Missing route " + metadata.appName + ", did you set quarkus.openshift.route.expose=true?");
             }
             if (route.getSpec().getTls() != null) {
                 RestAssured.useRelaxedHTTPSValidation();

--- a/config-secret/api-server/src/main/resources/application.properties
+++ b/config-secret/api-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.secrets.enabled=true
 quarkus.kubernetes-config.secrets=app-config

--- a/config-secret/file-system/src/main/resources/application.properties
+++ b/config-secret/file-system/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.app-secret=app-config
 
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/configmap/api-server/src/main/resources/application.properties
+++ b/configmap/api-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.config-maps=app-config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/configmap/file-system/src/main/resources/application.properties
+++ b/configmap/file-system/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.app-config-map=app-config
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 

--- a/deployment-strategies/quarkus/src/main/resources/application.properties
+++ b/deployment-strategies/quarkus/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.application.name=deployment-strategy-quarkus
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/HeroesOpenShiftIT.java
@@ -67,7 +67,7 @@ public class HeroesOpenShiftIT {
     public void testOpenApi() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/openapi")
+                .when().get(url + "/q/openapi")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -76,7 +76,7 @@ public class HeroesOpenShiftIT {
     public void testLiveness() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/health/live")
+                .when().get(url + "/q/health/live")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -85,7 +85,7 @@ public class HeroesOpenShiftIT {
     public void testReadiness() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/health/ready")
+                .when().get(url + "/q/health/ready")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -94,7 +94,7 @@ public class HeroesOpenShiftIT {
     public void testMetrics() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/metrics/application")
+                .when().get(url + "/q/metrics/application")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -179,7 +179,7 @@ public class HeroesOpenShiftIT {
     public void testCalledOperationMetrics() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/metrics/application")
+                .when().get(url + "/q/metrics/application")
                 .then()
                 .statusCode(OK.getStatusCode())
                 .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countCreateHero'", is(1))

--- a/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
+++ b/external-applications/quarkus-workshop-super-heroes/src/test/java/io/quarkus/ts/openshift/heroes/workshop/VillainsOpenShiftIT.java
@@ -68,7 +68,7 @@ public class VillainsOpenShiftIT {
     public void testOpenApi() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/openapi")
+                .when().get(url + "/q/openapi")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -77,7 +77,7 @@ public class VillainsOpenShiftIT {
     public void testLiveness() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/health/live")
+                .when().get(url + "/q/health/live")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -86,7 +86,7 @@ public class VillainsOpenShiftIT {
     public void testReadiness() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/health/ready")
+                .when().get(url + "/q/health/ready")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -95,7 +95,7 @@ public class VillainsOpenShiftIT {
     public void testMetrics() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/metrics/application")
+                .when().get(url + "/q/metrics/application")
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -180,7 +180,7 @@ public class VillainsOpenShiftIT {
     public void testCalledOperationMetrics() {
         given()
                 .header(ACCEPT, APPLICATION_JSON)
-                .when().get(url + "/metrics/application")
+                .when().get(url + "/q/metrics/application")
                 .then()
                 .statusCode(OK.getStatusCode())
                 .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countCreateVillain'", is(1))

--- a/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/CustomGrpcService.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/CustomGrpcService.java
@@ -1,14 +1,13 @@
 package io.quarkus.ts.openshift.http;
 
-import javax.inject.Singleton;
-
 import io.grpc.stub.StreamObserver;
 import io.quarkus.example.GreeterGrpc;
 import io.quarkus.example.HelloReply;
 import io.quarkus.example.HelloRequest;
+import io.quarkus.grpc.GrpcService;
 
-@Singleton
-public class GrpcService extends GreeterGrpc.GreeterImplBase {
+@GrpcService
+public class CustomGrpcService extends GreeterGrpc.GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {

--- a/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/GrpcResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/GrpcResource.java
@@ -9,13 +9,13 @@ import javax.ws.rs.core.MediaType;
 
 import io.quarkus.example.GreeterGrpc;
 import io.quarkus.example.HelloRequest;
-import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.GrpcClient;
 
 @Path("/grpc")
 public class GrpcResource {
 
     @Inject
-    @GrpcService("hello")
+    @GrpcClient("hello")
     GreeterGrpc.GreeterBlockingStub client;
 
     @GET

--- a/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/HttpClientVersionResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/openshift/http/HttpClientVersionResource.java
@@ -4,7 +4,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.vertx.web.Route;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
@@ -12,7 +11,7 @@ public class HttpClientVersionResource {
 
     protected static final String HTTP_VERSION = "x-http-version";
 
-    @Route(methods = HttpMethod.GET, path = "/httpVersion")
+    @Route(methods = Route.HttpMethod.GET, path = "/httpVersion")
     public void clientHttpVersion(RoutingContext rc) {
         String httpClientVersion = rc.request().version().name();
         rc.response().headers().add(HTTP_VERSION, httpClientVersion);

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 
 quarkus.application.name=test-http-advanced
 quarkus.http.root-path=/api
-quarkus.http.non-application-root-path=/q
-quarkus.http.redirect-to-non-application-root-path=true
 
 #quarkus.smallrye-metrics.path=/metricas
 quarkus.http.port=8081
@@ -12,7 +10,7 @@ quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 
 quarkus.kubernetes.deployment-target=openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 quarkus.http.http2=true
 quarkus.http.ssl-port=8443
@@ -49,18 +47,6 @@ quarkus.keycloak.policy-enforcer.enable=true
 # Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead
 quarkus.keycloak.policy-enforcer.paths.health-redirection.path=/api/q/*
 quarkus.keycloak.policy-enforcer.paths.health-redirection.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.metrics.path=/api/metrics/*
-quarkus.keycloak.policy-enforcer.paths.metrics.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.openapi.path=/api/openapi/*
-quarkus.keycloak.policy-enforcer.paths.openapi.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.swagger-ui.path=/api/swagger-ui/*
-quarkus.keycloak.policy-enforcer.paths.swagger-ui.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.health.path=/api/health/*
-quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
 quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED

--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -4,7 +4,6 @@ import static io.quarkus.ts.openshift.http.HttpClientVersionResource.HTTP_VERSIO
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
@@ -130,17 +129,13 @@ public abstract class AbstractHttpTest {
 
     @Test
     @DisplayName("Non-application endpoint move to /q/")
-    public void nonAppRedirections() {
+    public void nonAppEndpoints() {
         List<String> endpoints = Arrays.asList(
-                "/openapi", "/swagger-ui", "/metrics/base", "/metrics/application",
-                "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",
-                "/health/live", "/health");
+                "q/openapi", "q/swagger-ui", "q/metrics/base", "q/metrics/application",
+                "q/metrics/vendor", "q/metrics", "q/health/group", "q/health/well", "q/health/ready",
+                "q/health/live", "q/health");
 
         for (String endpoint : endpoints) {
-            given().redirects().follow(false)
-                    .log().uri()
-                    .expect().statusCode(301).header("Location", containsString("/q" + endpoint)).when().get(endpoint);
-
             given().expect().statusCode(in(Arrays.asList(200, 204))).when().get(endpoint);
         }
     }
@@ -161,7 +156,7 @@ public abstract class AbstractHttpTest {
     public void vertxHttpClientRedirection() throws InterruptedException, URISyntaxException {
         CountDownLatch done = new CountDownLatch(1);
         Uni<Integer> statusCode = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions())
-                .getAbs(getAppEndpoint() + "health")
+                .getAbs(getAppEndpoint() + "q/health")
                 .send().map(HttpResponse::statusCode)
                 .ifNoItem().after(Duration.ofSeconds(TIMEOUT_SEC)).fail()
                 .onFailure().retry().atMost(RETRY);

--- a/http/http-minimum/src/main/resources/application.properties
+++ b/http/http-minimum/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.application.name=test-http
 quarkus.http.root-path=/api
 quarkus.kubernetes.deployment-target=openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.kubernetes.readiness-probe.period=5s

--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -17,7 +17,7 @@ quarkus.infinispan-client.trust-store-password=password
 quarkus.infinispan-client.trust-store-type=JKS
 
 # instructs quarkus to build and deploy to kubernetes/openshift, and to trust the Kubernetes API since we're using self-signed
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # configmap settings

--- a/lifecycle-application/src/main/resources/application.properties
+++ b/lifecycle-application/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 
 # We can't append arguments to the Java commend
 # Not sure if the quarkus.openshift.arguments will be the right property to do this or there will be a new one.

--- a/messaging/amqp-reactive/src/main/java/io/quarkus/ts/openshift/messaging/amqp/PriceProducer.java
+++ b/messaging/amqp-reactive/src/main/java/io/quarkus/ts/openshift/messaging/amqp/PriceProducer.java
@@ -1,13 +1,13 @@
 package io.quarkus.ts.openshift.messaging.amqp;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logging.Logger;
 
-import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class PriceProducer {
@@ -15,10 +15,10 @@ public class PriceProducer {
     private static final Logger LOG = Logger.getLogger(PriceProducer.class.getName());
 
     @Outgoing("generated-price")
-    public Flowable<Integer> generate() {
+    public Multi<Integer> generate() {
         LOG.info("generate fired...");
-        return Flowable.interval(1, TimeUnit.SECONDS)
-                .onBackpressureDrop()
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .onOverflow().drop()
                 .map(tick -> ((tick.intValue() * 10) % 100) + 10);
     }
 }

--- a/messaging/amqp-reactive/src/main/resources/application.properties
+++ b/messaging/amqp-reactive/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.amqp-host=localhost

--- a/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ConsumerService.java
+++ b/messaging/artemis-jta/src/main/java/io/quarkus/ts/openshift/messaging/artemisjta/ConsumerService.java
@@ -9,7 +9,6 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -41,7 +40,7 @@ public class ConsumerService {
     }
 
     private String receiveMessagesInQueue(String queueName) {
-        String price = StringUtils.EMPTY;
+        String price = "";
         try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE);
                 JMSConsumer consumer = context.createConsumer(context.createQueue(queueName))) {
             Message message = consumer.receive(500);

--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.artemis.url=tcp://amq-broker-tcp:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616

--- a/messaging/artemis/src/main/resources/application.properties
+++ b/messaging/artemis/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.artemis.url=tcp://amq-broker-tcp:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616

--- a/messaging/kafka-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-avro-reactive-messaging/pom.xml
@@ -83,6 +83,7 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -90,10 +91,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
@@ -27,4 +27,4 @@ mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest
 mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
 mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/application.properties
@@ -24,7 +24,7 @@ quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.kubernetes.readiness-probe.period=5s
 quarkus.kubernetes.readiness-probe.initial-delay=0s
 quarkus.kubernetes.readiness-probe.failure-threshold=5

--- a/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
@@ -40,4 +40,4 @@ kafka-streams.consumer.heartbeat.interval.ms=80
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/messaging/qpid/src/main/resources/application.properties
+++ b/messaging/qpid/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # QPID

--- a/micrometer/prometheus-kafka/src/main/resources/application.properties
+++ b/micrometer/prometheus-kafka/src/main/resources/application.properties
@@ -13,7 +13,7 @@ mp.messaging.incoming.alerts-target.value.deserializer=org.apache.kafka.common.s
 
 # Openshift
 quarkus.openshift.labels.app-with-metrics=quarkus-app
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s

--- a/micrometer/prometheus-kafka/src/test/resources/service-monitor.yaml
+++ b/micrometer/prometheus-kafka/src/test/resources/service-monitor.yaml
@@ -8,6 +8,7 @@ spec:
   endpoints:
   - interval: 30s
     targetPort: 8080
+    path: /q/metrics
     scheme: http
   selector:
     matchLabels:

--- a/micrometer/prometheus/src/main/resources/application.properties
+++ b/micrometer/prometheus/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.openshift.labels.app-with-metrics=quarkus-app
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 # Openshift

--- a/micrometer/prometheus/src/test/resources/service-monitor.yaml
+++ b/micrometer/prometheus/src/test/resources/service-monitor.yaml
@@ -8,6 +8,7 @@ spec:
   endpoints:
   - interval: 30s
     targetPort: 8080
+    path: /q/metrics
     scheme: http
   selector:
     matchLabels:

--- a/microprofile/src/main/java/io/quarkus/ts/openshift/microprofile/HelloClient.java
+++ b/microprofile/src/main/java/io/quarkus/ts/openshift/microprofile/HelloClient.java
@@ -13,7 +13,7 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@RegisterRestClient(baseUri = "http://microprofile-test:8080/")
+@RegisterRestClient(baseUri = "http://microprofile-test/")
 public interface HelloClient {
     @GET
     @Path("/hello")

--- a/microprofile/src/main/resources/application.properties
+++ b/microprofile/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.jaeger.sampler-param=1
 quarkus.jaeger.endpoint=http://jaeger-collector:14268/api/traces
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s

--- a/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/MicroProfileOpenShiftIT.java
+++ b/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/MicroProfileOpenShiftIT.java
@@ -67,14 +67,14 @@ public class MicroProfileOpenShiftIT extends AbstractMicroProfileTest {
                             hasItems(
                                     "span.kind=client",
                                     "component=jaxrs",
-                                    "http.url=http://microprofile-test:8080/hello",
+                                    "http.url=http://microprofile-test/hello",
                                     "http.method=GET",
                                     "http.status_code=200"))
                     .body("data[0].spans.find { it.operationName == 'GET:io.quarkus.ts.openshift.microprofile.HelloResource.get' }.tags.collect { \"${it.key}=${it.value}\".toString() }",
                             hasItems(
                                     "span.kind=server",
                                     "component=jaxrs",
-                                    "http.url=http://microprofile-test:8080/hello",
+                                    "http.url=http://microprofile-test/hello",
                                     "http.method=GET",
                                     "http.status_code=200"));
         });

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     </modules>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
@@ -66,14 +66,16 @@
         <!-- same as Apache HTTP Client managed by Quarkus BOM -->
         <version.fusesource-jansi>2.3.2</version.fusesource-jansi>
         <version.impsort-maven-plugin>1.6.2</version.impsort-maven-plugin>
-        <version.jandex-maven-plugin>1.0.8</version.jandex-maven-plugin>
+        <version.jandex-maven-plugin>1.1.0</version.jandex-maven-plugin>
         <version.jjwt>0.11.2</version.jjwt>
+        <version.quarkus.qpid.jms>0.24.0</version.quarkus.qpid.jms>
         <version.apache.avro>1.10.2</version.apache.avro>
+        <version.htmlunit>2.40.0</version.htmlunit>
         <version.keytool-maven-plugin>1.5</version.keytool-maven-plugin>
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>1.13.4.Final</version.quarkus>
+        <version.quarkus>2.0.2.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.15.3</version.testcontainers>
         <version.com.squareup.retrofit2>2.9.0</version.com.squareup.retrofit2>
@@ -168,6 +170,16 @@
                 <artifactId>retrofit</artifactId>
                 <version>${version.com.squareup.retrofit2}</version>
             </dependency>
+            <dependency>
+                <groupId>org.amqphub.quarkus</groupId>
+                <artifactId>quarkus-qpid-jms</artifactId>
+                <version>${version.quarkus.qpid.jms}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${version.htmlunit}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -248,6 +260,7 @@
                         <execution>
                             <goals>
                                 <goal>build</goal>
+                                <goal>generate-code</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -301,24 +314,6 @@
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>${version.jandex-maven-plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro-maven-plugin</artifactId>
-                    <version>${version.apache.avro}</version>
-                    <executions>
-                        <execution>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>schema</goal>
-                            </goals>
-                            <configuration>
-                                <sourceDirectory>src/main/avro</sourceDirectory>
-                                <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                                <stringType>String</stringType>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/scaling/src/main/resources/application.properties
+++ b/scaling/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.application.name=test-scaling
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # Openshift

--- a/security/basic/src/main/resources/application.properties
+++ b/security/basic/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.security.users.embedded.roles.albert=admin,user
 quarkus.security.users.embedded.roles.isaac=user
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/jwt-cookie/src/main/resources/application.properties
+++ b/security/jwt-cookie/src/main/resources/application.properties
@@ -6,7 +6,7 @@ smallrye.jwt.token.cookie=MY_COOKIE_NAME
 
 quarkus.security.deny-unannotated-members=true
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # Openshift

--- a/security/jwt/src/main/resources/application.properties
+++ b/security/jwt/src/main/resources/application.properties
@@ -4,7 +4,7 @@ smallrye.jwt.expiration.grace=120
 
 quarkus.security.deny-unannotated-members=true
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 # Openshift

--- a/security/keycloak-authz/src/main/resources/application.properties
+++ b/security/keycloak-authz/src/main/resources/application.properties
@@ -14,7 +14,7 @@ quarkus.keycloak.policy-enforcer.paths.resources.path=/*
 quarkus.keycloak.policy-enforcer.paths.resources.enforcement-mode=ENFORCING
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-jwt/src/main/resources/application.properties
+++ b/security/keycloak-jwt/src/main/resources/application.properties
@@ -10,7 +10,7 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.roles.source=accesstoken
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-multitenant/src/main/resources/application.properties
+++ b/security/keycloak-multitenant/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.oidc.jwt-tenant.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.jwt-tenant.roles.source=accesstoken
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-oauth2/src/main/resources/application.properties
+++ b/security/keycloak-oauth2/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.oauth2.client-secret=test-application-client-secret
 quarkus.oauth2.role-claim=roles
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-oidc-client/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client/src/main/resources/application.properties
@@ -33,7 +33,7 @@ quarkus.oidc-client.jwt-secret.client-id=test-application-client-jwt
 quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak-webapp/src/main/resources/application.properties
+++ b/security/keycloak-webapp/src/main/resources/application.properties
@@ -15,7 +15,7 @@ quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Openshift
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/keycloak/src/main/resources/application.properties
+++ b/security/keycloak/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.oidc.token.lifespan-grace=5
 
 # Openshift
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.openshift.readiness-probe.period=5s
 quarkus.openshift.readiness-probe.initial-delay=0s
 quarkus.openshift.readiness-probe.failure-threshold=5

--- a/sql-db/mariadb/src/main/resources/application.properties
+++ b/sql-db/mariadb/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mariadb

--- a/sql-db/mssql/src/main/resources/application.properties
+++ b/sql-db/mssql/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mssql

--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.MARIA_DB_DATABASE.secret=mariadb

--- a/sql-db/mysql/src/main/resources/application.properties
+++ b/sql-db/mysql/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=mysql

--- a/sql-db/postgresql/src/main/resources/application.properties
+++ b/sql-db/postgresql/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11
 
 quarkus.openshift.env-vars.DB_DATABASE.secret=postgresql


### PR DESCRIPTION
- Openshift Service default port has moved from 8080 to 80
- HtmlUnit lib has removed from universe bom
- Non-application endpoint doesn't do a redirection anymore
- io.quarkus.grpc.runtime.annotations.GrpcService annotation was renamed to io.quarkus.grpc.GrpcClient
- Vert.x4: some references as `io.vertx.core.http.HttpMethod` are not available anymore
- `quarkus.openshift.expose` property has been moved to `quarkus.openshift.route.expose`
- Upgrade to Java 11
- Remove avro-maven-plugin
- @quarkus.security.Authenticated is not required anymore