### PR TITLE
Fix configuration mistake leading to failures in MultiplePersistenceUnitTest

### DIFF
--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -18,6 +18,9 @@ quarkus.hibernate-orm."fruits".database.generation=drop-and-create
 quarkus.hibernate-orm."fruits".sql-load-script=import-fruits.sql
 quarkus.hibernate-orm."fruits".datasource=fruits
 quarkus.hibernate-orm."fruits".packages=io.quarkus.ts.openshift.sqldb.multiplepus.model.fruit
+# Quarkus defaults to org.hibernate.dialect.MariaDB103Dialect,
+# but we're using MariaDB 10.2, and apparently the person who
+# wrote this config decided they absolutely needed MariaDB102Dialect.
 quarkus.hibernate-orm."fruits".dialect=org.hibernate.dialect.MariaDB102Dialect
 
 quarkus.openshift.env-vars.POSTGRESQL_DB_DATABASE.secret=postgresql

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/MultiplePersistenceUnitTest.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/MultiplePersistenceUnitTest.java
@@ -1,10 +1,7 @@
 package io.quarkus.ts.openshift.sqldb.multiplepus;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@Disabled("https://github.com/quarkusio/quarkus/issues/15836")
 public class MultiplePersistenceUnitTest extends AbstractMultiplePersistenceUnitTest {
 }

--- a/sql-db/multiple-pus/src/test/resources/application.properties
+++ b/sql-db/multiple-pus/src/test/resources/application.properties
@@ -7,6 +7,8 @@
 %test.quarkus.hibernate-orm."fruits".sql-load-script=import-fruits.sql
 %test.quarkus.hibernate-orm."fruits".datasource=fruits
 %test.quarkus.hibernate-orm."fruits".packages=io.quarkus.ts.openshift.sqldb.multiplepus.model.fruit
+# Unset the explicit MariadDB dialect from the main application.properties
+%test.quarkus.hibernate-orm."fruits".dialect=
 
 %test.quarkus.datasource."vegetables".db-kind=h2
 %test.quarkus.datasource."vegetables".jdbc.url=jdbc:h2:mem:vegetables


### PR DESCRIPTION
The test was failing simply because we were telling Quarkus to use a MariaDB dialect, while using an H2 database.
I suppose it used to work with Quarkus 1.x because for some reason the dialect was being ignored, or because the H2 dialect was close enough to the MariaDB dialect. In any case, that was fixed in Quarkus 2.0, so now the invalid dialect configuration is a problem and must be fixed.

See also https://github.com/quarkusio/quarkus/issues/15836.