### PR TITLE
Upgrade to 2.1.3.Final and fix 999-SNAPSHOT

### DIFF
--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/AwaitUtil.java
@@ -11,8 +11,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.Handlers;
-import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.quarkus.ts.openshift.app.metadata.AppMetadata;
 import io.quarkus.ts.openshift.common.DefaultTimeout;
@@ -68,13 +66,15 @@ public final class AwaitUtil {
                             .until(() -> {
                                 HasMetadata current = oc.resource(it).fromServer().get();
                                 if (current == null) {
-                                    ResourceHandler<HasMetadata, ?> handler = Handlers.get(it.getKind(), it.getApiVersion());
-                                    if (handler != null && !handler.getApiVersion().equals(it.getApiVersion())) {
-                                        throw new OpenShiftTestException("Couldn't load " + readableKind(it.getKind()) + " '"
-                                                + it.getMetadata().getName() + "' from API server, most likely because"
-                                                + " the 'apiVersion' doesn't match: has '" + it.getApiVersion() + "', but"
-                                                + " should have '" + handler.getApiVersion() + "'");
-                                    }
+                                    // We can't get the metadata info from Fabric8 client any longer.
+                                    // Reported in https://github.com/fabric8io/kubernetes-client/issues/3413
+                                    // ResourceHandler<HasMetadata, ?> handler = Handlers.get(it.getKind(), it.getApiVersion());
+                                    // if (handler != null && !handler.getApiVersion().equals(it.getApiVersion())) {
+                                    //     throw new OpenShiftTestException("Couldn't load " + readableKind(it.getKind()) + " '"
+                                    //            + it.getMetadata().getName() + "' from API server, most likely because"
+                                    //            + " the 'apiVersion' doesn't match: has '" + it.getApiVersion() + "', but"
+                                    //            + " should have '" + handler.getApiVersion() + "'");
+                                    // }
                                     throw new OpenShiftTestException("Couldn't load " + readableKind(it.getKind()) + " '"
                                             + it.getMetadata().getName() + "' from API server");
                                 }

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.quarkus>2.1.2.Final</version.quarkus>
+        <version.quarkus>2.1.3.Final</version.quarkus>
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.16.0</version.testcontainers>
         <version.com.squareup.retrofit2>2.9.0</version.com.squareup.retrofit2>


### PR DESCRIPTION
The Fabric8 API brings another breaking change, so I had to drop some nice information about why a resource is not loaded.