### PR TITLE
Bump formatter-maven-plugin from 2.18.0 to 2.19.0

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/openshift/http/AbstractHttpTest.java
@@ -113,10 +113,10 @@ public abstract class AbstractHttpTest {
     public void http2ClientAsync() throws Exception {
         HttpVersionClientServiceAsync clientServiceAsync = new RestClientServiceBuilder<HttpVersionClientServiceAsync>(
                 getAppEndpoint())
-                        .withHostVerified(true)
-                        .withPassword(PASSWORD)
-                        .withKeyStorePath(KEY_STORE_PATH)
-                        .build(HttpVersionClientServiceAsync.class);
+                .withHostVerified(true)
+                .withPassword(PASSWORD)
+                .withKeyStorePath(KEY_STORE_PATH)
+                .build(HttpVersionClientServiceAsync.class);
 
         Response resp = clientServiceAsync
                 .getClientHttpVersion()

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.plugin.quarkus>${version.quarkus}</version.plugin.quarkus>
         <version.testcontainers>1.17.2</version.testcontainers>
         <version.com.squareup.retrofit2>2.9.0</version.com.squareup.retrofit2>
-        <version.formatter-maven-plugin>2.18.0</version.formatter-maven-plugin>
+        <version.formatter-maven-plugin>2.19.0</version.formatter-maven-plugin>
         <version.impsort-maven-plugin>1.6.0</version.impsort-maven-plugin>
         <version.xml-format-maven-plugin>3.2.1</version.xml-format-maven-plugin>
         <src.format.goal>format</src.format.goal>


### PR DESCRIPTION
Bump formatter-maven-plugin from 2.18.0 to 2.19.0

Replaces https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/415