### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
             </activation>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11</quarkus.native.builder-image>
                 <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
                 <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>


### PR DESCRIPTION
Updates GraalVM/Mandrel version to 22.2.