### PR TITLE
Fix for Quarkus main after move to kubernetes-client 6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,56 +2,56 @@ name: "Pull Request CI"
 on:
   - pull_request
 jobs:
-  build-released:
-    name: JVM build - released Quarkus
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: openjdk${{ matrix.java }}
-      - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean test -Dinclude.serverless -Dinclude.datagrid -Dvalidate-format
-      - name: Zip Artifacts
-        run: |
-          zip -R artifacts-jvm${{ matrix.java }}.zip 'surefire-reports/*'
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ci-artifacts
-          path: artifacts-jvm${{ matrix.java }}.zip
-  build-released-native:
-    name: Native build - released Quarkus
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: openjdk${{ matrix.java }}
-      - name: Build with Maven
-        run: |
-          mvn -fae -V -B clean install -s .github/mvn-settings.xml -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http/http-minimum' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker
+#  build-released:
+#    name: JVM build - released Quarkus
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        java: [ 11 ]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/cache@v1
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Install JDK {{ matrix.java }}
+#        # Uses sha for added security since tags can be updated
+#        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+#        with:
+#          java-version: openjdk${{ matrix.java }}
+#      - name: Build with Maven
+#        run: mvn -fae -V -B -s .github/mvn-settings.xml clean test -Dinclude.serverless -Dinclude.datagrid -Dvalidate-format
+#      - name: Zip Artifacts
+#        run: |
+#          zip -R artifacts-jvm${{ matrix.java }}.zip 'surefire-reports/*'
+#      - uses: actions/upload-artifact@v1
+#        with:
+#          name: ci-artifacts
+#          path: artifacts-jvm${{ matrix.java }}.zip
+#  build-released-native:
+#    name: Native build - released Quarkus
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        java: [ 11 ]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/cache@v1
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Install JDK {{ matrix.java }}
+#        # Uses sha for added security since tags can be updated
+#        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+#        with:
+#          java-version: openjdk${{ matrix.java }}
+#      - name: Build with Maven
+#        run: |
+#          mvn -fae -V -B clean install -s .github/mvn-settings.xml -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http/http-minimum' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker
   build-main:
     name: JVM build - Quarkus main
     runs-on: ubuntu-latest
@@ -82,3 +82,26 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-jvm${{ matrix.java }}.zip
+  build-main-native:
+    name: JVM build - Quarkus main
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK {{ matrix.java }}
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          java-version: openjdk${{ matrix.java }}
+      - name: Build Quarkus main
+        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
+      - name: Build with Maven
+        run: mvn -fae -V -B clean verify -s .github/mvn-settings.xml -Dquarkus-core-only -DskipTests -DskipITs -pl 'app-metadata/deployment,app-metadata/runtime,common,http/http-minimum,http/http-advanced' -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/OpenShiftUtil.java
@@ -20,7 +20,6 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.quarkus.ts.openshift.common.DefaultTimeout;
 import io.quarkus.ts.openshift.common.OpenShiftTestException;
-import okhttp3.Response;
 
 public final class OpenShiftUtil {
     private final OpenShiftClient oc;

--- a/common/src/main/java/io/quarkus/ts/openshift/common/util/ReadinessUtil.java
+++ b/common/src/main/java/io/quarkus/ts/openshift/common/util/ReadinessUtil.java
@@ -8,9 +8,9 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
+import io.fabric8.openshift.client.readiness.OpenShiftReadiness;
 
 /**
  * Unifies Fabric8 Kubernetes Client's {@link Readiness} and {@link OpenShiftReadiness}.


### PR DESCRIPTION
Fix for Quarkus main after move to kubernetes-client 6.x

Needs Quarkus 2.14 to be release to be able to merge this PR. Quarkus 2.13 uses kubernetes-client 5.x.