### PR TITLE
Move to new builder images introduced in Quarkus 2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ will execute the whole test suite using Docker to run containers for native buil
   -Dts.authenticated-registry
 ```
 
-Currently used builder image is `quarkus/ubi-quarkus-mandrel` and the base image for OpenShift deployment is 
+Currently used builder image is `quarkus/ubi-quarkus-mandrel-builder-image` and the base image for OpenShift deployment is 
 `quarkus/ubi-quarkus-native-binary-s2i`.
 
 ### OpenShift Serverless / Knative

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.fast-jar
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.fast-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-fast-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.jvm
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.legacy-jar
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.native
+++ b/deployment-strategies/quarkus-serverless/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/openshift-quickstart
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/deployment-strategies/quarkus/src/main/docker/Dockerfile.fast-jar
+++ b/deployment-strategies/quarkus/src/main/docker/Dockerfile.fast-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-fast-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus/src/main/docker/Dockerfile.jvm
+++ b/deployment-strategies/quarkus/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus/src/main/docker/Dockerfile.legacy-jar
+++ b/deployment-strategies/quarkus/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/openshift-quickstart-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/deployment-strategies/quarkus/src/main/docker/Dockerfile.native
+++ b/deployment-strategies/quarkus/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/openshift-quickstart
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/pom.xml
+++ b/pom.xml
@@ -384,8 +384,8 @@
             </activation>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17</quarkus.native.builder-image>
-                <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0</quarkus.s2i.base-jvm-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17</quarkus.native.builder-image>
+                <quarkus.s2i.base-jvm-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0</quarkus.s2i.base-jvm-image>
                 <quarkus.native.native-image-xmx>3g</quarkus.native.native-image-xmx>
             </properties>
         </profile>


### PR DESCRIPTION
Move to new builder images introduced in Quarkus 2.14

PR with the change - https://github.com/quarkusio/quarkus/pull/27997

NEW is active - https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags
OLD is without update for 3 months - https://quay.io/repository/quarkus/ubi-quarkus-mandrel?tab=tags