### PR TITLE
Switch to quarkus-extension-maven-plugin

### DIFF
--- a/app-metadata/runtime/pom.xml
+++ b/app-metadata/runtime/pom.xml
@@ -20,7 +20,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${version.plugin.quarkus}</version>
                 <executions>
                     <execution>


### PR DESCRIPTION
Switch to quarkus-extension-maven-plugin

Deprecated quarkus-bootstrap-maven-plugin was removed in Quarkus main / Quarkus CR1