### PR TITLE
Bump htmlunit to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.quarkus.qpid.jms>2.4.0</version.quarkus.qpid.jms>
         <version.apache.avro>1.10.2</version.apache.avro>
         <version.assertj>3.24.2</version.assertj>
-        <version.htmlunit>2.55.0</version.htmlunit>
+        <version.htmlunit>3.5.0</version.htmlunit>
         <version.keytool-maven-plugin>1.5</version.keytool-maven-plugin>
         <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
@@ -180,7 +180,7 @@
                 <version>${version.quarkus.qpid.jms}</version>
             </dependency>
             <dependency>
-                <groupId>net.sourceforge.htmlunit</groupId>
+                <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
                 <version>${version.htmlunit}</version>
             </dependency>

--- a/security/keycloak-jwt/pom.xml
+++ b/security/keycloak-jwt/pom.xml
@@ -42,7 +42,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -6,15 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Optional;
 
 import org.apache.http.HttpStatus;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 public abstract class AbstractSecurityKeycloakOpenShiftTest {
 
@@ -77,8 +76,8 @@ public abstract class AbstractSecurityKeycloakOpenShiftTest {
     private void whenLoginAs(String user) throws Exception {
         HtmlForm loginForm = page.getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(user);
-        loginForm.getInputByName("password").setValueAttribute(user);
+        loginForm.getInputByName("username").setValue(user);
+        loginForm.getInputByName("password").setValue(user);
 
         page = loginForm.getInputByName("login").click();
     }

--- a/security/keycloak-multitenant/pom.xml
+++ b/security/keycloak-multitenant/pom.xml
@@ -42,7 +42,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -10,6 +10,12 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.impl.client.HttpClients;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,13 +23,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.Configuration;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 public abstract class AbstractSecurityKeycloakOpenShiftTest {
 
@@ -108,8 +107,8 @@ public abstract class AbstractSecurityKeycloakOpenShiftTest {
     private TextPage whenLogin(HtmlPage loginPage, String user) throws Exception {
         HtmlForm loginForm = loginPage.getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(USER);
-        loginForm.getInputByName("password").setValueAttribute(USER);
+        loginForm.getInputByName("username").setValue(USER);
+        loginForm.getInputByName("password").setValue(USER);
         return loginForm.getInputByName("login").click();
     }
 

--- a/security/keycloak-webapp/pom.xml
+++ b/security/keycloak-webapp/pom.xml
@@ -38,7 +38,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/openshift/security/keycloak/AbstractSecurityKeycloakOpenShiftTest.java
@@ -10,18 +10,17 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.Page;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 public abstract class AbstractSecurityKeycloakOpenShiftTest {
 
@@ -140,8 +139,8 @@ public abstract class AbstractSecurityKeycloakOpenShiftTest {
         assertTrue(page instanceof HtmlPage, "Should be in an HTML page");
         HtmlForm loginForm = ((HtmlPage) page).getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(user);
-        loginForm.getInputByName("password").setValueAttribute(user);
+        loginForm.getInputByName("username").setValue(user);
+        loginForm.getInputByName("password").setValue(user);
 
         page = loginForm.getInputByName("login").click();
     }


### PR DESCRIPTION
* Updating htmlunit to 3.5.0, along with relocations required by the htmlunit migration guide (https://www.htmlunit.org/migration.html).